### PR TITLE
Add desktop tests for pure functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Desktop Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -B test/build test/
+
+      - name: Build
+        run: cmake --build test/build
+
+      - name: Run tests
+        run: cd test/build && ctest --output-on-failure

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ To rotate the API key, update both:
 1. `secrets.h` on the Arduino
 2. `AUTO_DJ_API_KEY` env var on the tubafrenzy server
 
+## Running Tests
+
+Pure logic functions (`urlEncode`, `parseRadioShowID`, `currentHourMs`) are extracted into `utils.h`/`utils.cpp` and tested on desktop using GoogleTest with a minimal Arduino `String` shim. No Arduino hardware or SDK required.
+
+```bash
+cd test
+cmake -B build
+cmake --build build
+cd build && ctest --output-on-failure
+```
+
+Tests run automatically on push and PR via GitHub Actions (`.github/workflows/test.yml`).
+
 ## Known Limitations
 
 - **WiFi reconnection blocks for ~36 seconds** (known Giga R1 firmware limitation). During this time, the state machine is frozen. Track changes during a WiFi outage are not logged retroactively.

--- a/auto-dj-arduino-switch/flowsheet_client.h
+++ b/auto-dj-arduino-switch/flowsheet_client.h
@@ -41,7 +41,6 @@ private:
     int port;
     const char* apiKey;
 
-    String urlEncode(const String& str);
     int postForm(const char* path, const String& body);
     String getLocationHeader(const char* path, const String& body);
 };

--- a/auto-dj-arduino-switch/utils.cpp
+++ b/auto-dj-arduino-switch/utils.cpp
@@ -1,0 +1,45 @@
+#include "utils.h"
+
+String urlEncode(const String& str) {
+    String encoded;
+    encoded.reserve(str.length() * 2);
+    for (unsigned int i = 0; i < str.length(); i++) {
+        char c = str.charAt(i);
+        if (isAlphaNumeric(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            encoded += c;
+        } else if (c == ' ') {
+            encoded += '+';
+        } else {
+            encoded += '%';
+            if ((unsigned char)c < 0x10) encoded += '0';
+            encoded += String((unsigned char)c, HEX);
+        }
+    }
+    return encoded;
+}
+
+int parseRadioShowID(const String& location) {
+    int idx = location.indexOf("radioShowID=");
+    if (idx < 0) {
+        return -1;
+    }
+
+    String idStr = location.substring(idx + 12); // length of "radioShowID="
+    int ampIdx = idStr.indexOf('&');
+    if (ampIdx >= 0) {
+        idStr = idStr.substring(0, ampIdx);
+    }
+
+    int radioShowID = idStr.toInt();
+    if (radioShowID <= 0) {
+        return -1;
+    }
+
+    return radioShowID;
+}
+
+unsigned long currentHourMs(unsigned long epochSeconds) {
+    if (epochSeconds == 0) return 0;
+    unsigned long hourEpoch = epochSeconds - (epochSeconds % 3600);
+    return hourEpoch * 1000UL;
+}

--- a/auto-dj-arduino-switch/utils.h
+++ b/auto-dj-arduino-switch/utils.h
@@ -1,0 +1,26 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <Arduino.h>
+
+/**
+ * URL-encodes a string for use in HTTP form bodies.
+ * Unreserved characters (alphanumeric, '-', '_', '.', '~') pass through.
+ * Spaces become '+'. All other bytes are percent-encoded.
+ */
+String urlEncode(const String& str);
+
+/**
+ * Parses the radioShowID from a Location header value.
+ * Looks for "radioShowID=<digits>" in the string.
+ * Returns the ID, or -1 if not found or not a valid positive integer.
+ */
+int parseRadioShowID(const String& location);
+
+/**
+ * Truncates an epoch-seconds value to the hour boundary and converts to milliseconds.
+ * Returns 0 if epochSeconds is 0 (no NTP time available).
+ */
+unsigned long currentHourMs(unsigned long epochSeconds);
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.14)
+project(auto-dj-arduino-switch-tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+)
+FetchContent_MakeAvailable(googletest)
+
+# Build utils.cpp from the sketch directory, using our shim instead of real Arduino.h
+set(SKETCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../auto-dj-arduino-switch)
+
+add_library(utils STATIC ${SKETCH_DIR}/utils.cpp)
+target_include_directories(utils PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim   # Arduino.h shim
+    ${SKETCH_DIR}                       # utils.h
+)
+
+enable_testing()
+
+# Test executables
+add_executable(test_url_encode test_url_encode.cpp)
+target_link_libraries(test_url_encode PRIVATE utils GTest::gtest_main)
+
+add_executable(test_location_parsing test_location_parsing.cpp)
+target_link_libraries(test_location_parsing PRIVATE utils GTest::gtest_main)
+
+add_executable(test_current_hour_ms test_current_hour_ms.cpp)
+target_link_libraries(test_current_hour_ms PRIVATE utils GTest::gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(test_url_encode)
+gtest_discover_tests(test_location_parsing)
+gtest_discover_tests(test_current_hour_ms)

--- a/test/shim/Arduino.h
+++ b/test/shim/Arduino.h
@@ -1,0 +1,138 @@
+/**
+ * Minimal Arduino String shim for desktop testing.
+ *
+ * Implements just enough of the Arduino String class to compile and test
+ * the pure functions extracted into utils.h/utils.cpp. This is NOT a
+ * complete Arduino compatibility layer -- only the subset used by utils.cpp.
+ */
+#ifndef ARDUINO_H_SHIM
+#define ARDUINO_H_SHIM
+
+#include <string>
+#include <cstring>
+#include <cctype>
+#include <cstdio>
+#include <sstream>
+
+#define HEX 16
+
+inline bool isAlphaNumeric(char c) {
+    return std::isalnum(static_cast<unsigned char>(c));
+}
+
+class String {
+public:
+    String() : data_() {}
+    String(const char* s) : data_(s ? s : "") {}
+    String(const String& other) : data_(other.data_) {}
+
+    // Numeric constructors
+    String(int val) {
+        data_ = std::to_string(val);
+    }
+    String(unsigned long val) {
+        data_ = std::to_string(val);
+    }
+    String(unsigned char val, int base) {
+        if (base == HEX) {
+            char buf[8];
+            std::snprintf(buf, sizeof(buf), "%x", val);
+            data_ = buf;
+        } else {
+            data_ = std::to_string(val);
+        }
+    }
+
+    unsigned int length() const { return static_cast<unsigned int>(data_.size()); }
+    char charAt(unsigned int index) const { return data_[index]; }
+
+    int indexOf(const char* str) const {
+        auto pos = data_.find(str);
+        return pos == std::string::npos ? -1 : static_cast<int>(pos);
+    }
+    int indexOf(char c) const {
+        auto pos = data_.find(c);
+        return pos == std::string::npos ? -1 : static_cast<int>(pos);
+    }
+
+    String substring(unsigned int from) const {
+        if (from >= data_.size()) return String("");
+        return String(data_.substr(from).c_str());
+    }
+    String substring(unsigned int from, unsigned int to) const {
+        if (from >= data_.size()) return String("");
+        return String(data_.substr(from, to - from).c_str());
+    }
+
+    int toInt() const {
+        try {
+            return std::stoi(data_);
+        } catch (...) {
+            return 0;
+        }
+    }
+
+    void reserve(unsigned int size) {
+        data_.reserve(size);
+    }
+
+    bool equalsIgnoreCase(const String& other) const {
+        if (data_.size() != other.data_.size()) return false;
+        for (size_t i = 0; i < data_.size(); i++) {
+            if (std::tolower(static_cast<unsigned char>(data_[i])) !=
+                std::tolower(static_cast<unsigned char>(other.data_[i]))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    String& operator+=(char c) {
+        data_ += c;
+        return *this;
+    }
+    String& operator+=(const char* s) {
+        data_ += s;
+        return *this;
+    }
+    String& operator+=(const String& s) {
+        data_ += s.data_;
+        return *this;
+    }
+
+    String operator+(const char* s) const {
+        String result(*this);
+        result.data_ += s;
+        return result;
+    }
+    String operator+(const String& s) const {
+        String result(*this);
+        result.data_ += s.data_;
+        return result;
+    }
+
+    friend String operator+(const char* lhs, const String& rhs) {
+        String result(lhs);
+        result.data_ += rhs.data_;
+        return result;
+    }
+
+    bool operator==(const char* s) const { return data_ == s; }
+    bool operator==(const String& s) const { return data_ == s.data_; }
+    bool operator!=(const char* s) const { return data_ != s; }
+
+    const char* c_str() const { return data_.c_str(); }
+
+    // For test assertions
+    const std::string& str() const { return data_; }
+
+private:
+    std::string data_;
+};
+
+// Allow gtest to print String values
+inline std::ostream& operator<<(std::ostream& os, const String& s) {
+    return os << s.c_str();
+}
+
+#endif // ARDUINO_H_SHIM

--- a/test/test_current_hour_ms.cpp
+++ b/test/test_current_hour_ms.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include "utils.h"
+
+TEST(CurrentHourMs, TruncatesToHour) {
+    // 1705347000 = Mon Jan 15 2024 17:30:00 UTC -> truncates to 17:00:00 = 1705345200
+    EXPECT_EQ(currentHourMs(1705347000UL), 1705345200000UL);
+}
+
+TEST(CurrentHourMs, ExactHour) {
+    // Already on the hour boundary
+    EXPECT_EQ(currentHourMs(1705345200UL), 1705345200000UL);
+}
+
+TEST(CurrentHourMs, ZeroEpoch) {
+    // Guard: 0 means no NTP time, should return 0
+    EXPECT_EQ(currentHourMs(0UL), 0UL);
+}
+
+TEST(CurrentHourMs, OneSecondPastHour) {
+    EXPECT_EQ(currentHourMs(1705345201UL), 1705345200000UL);
+}
+
+TEST(CurrentHourMs, LastSecondOfHour) {
+    // 1705348799 = one second before the next hour (18:00:00 = 1705348800)
+    EXPECT_EQ(currentHourMs(1705348799UL), 1705345200000UL);
+}

--- a/test/test_location_parsing.cpp
+++ b/test/test_location_parsing.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include "utils.h"
+
+TEST(ParseRadioShowID, ValidLocation) {
+    EXPECT_EQ(parseRadioShowID("/playlists/flowsheet?mode=modifyFlowsheet&radioShowID=12345"), 12345);
+}
+
+TEST(ParseRadioShowID, TrailingParams) {
+    EXPECT_EQ(parseRadioShowID("/playlists/flowsheet?radioShowID=999&other=1"), 999);
+}
+
+TEST(ParseRadioShowID, MissingRadioShowID) {
+    EXPECT_EQ(parseRadioShowID("/playlists/flowsheet?mode=view"), -1);
+}
+
+TEST(ParseRadioShowID, EmptyString) {
+    EXPECT_EQ(parseRadioShowID(""), -1);
+}
+
+TEST(ParseRadioShowID, NonNumericID) {
+    EXPECT_EQ(parseRadioShowID("radioShowID=abc"), -1);
+}
+
+TEST(ParseRadioShowID, ZeroID) {
+    EXPECT_EQ(parseRadioShowID("radioShowID=0"), -1);
+}
+
+TEST(ParseRadioShowID, LargeID) {
+    EXPECT_EQ(parseRadioShowID("radioShowID=99999"), 99999);
+}

--- a/test/test_url_encode.cpp
+++ b/test/test_url_encode.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include "utils.h"
+
+TEST(UrlEncode, AlphanumericPassthrough) {
+    EXPECT_EQ(urlEncode("Hello123"), "Hello123");
+}
+
+TEST(UrlEncode, SpaceBecomesPlus) {
+    EXPECT_EQ(urlEncode("Hello World"), "Hello+World");
+}
+
+TEST(UrlEncode, SpecialCharsEncoded) {
+    EXPECT_EQ(urlEncode("a&b=c"), "a%26b%3dc");
+}
+
+TEST(UrlEncode, UnreservedPassthrough) {
+    EXPECT_EQ(urlEncode("a-b_c.d~e"), "a-b_c.d~e");
+}
+
+TEST(UrlEncode, SlashEncoded) {
+    EXPECT_EQ(urlEncode("artist/band"), "artist%2fband");
+}
+
+TEST(UrlEncode, EmptyString) {
+    EXPECT_EQ(urlEncode(""), "");
+}
+
+TEST(UrlEncode, HighByte) {
+    EXPECT_EQ(urlEncode("\xC3\xA9"), "%c3%a9");
+}


### PR DESCRIPTION
## Summary

- Extract `urlEncode`, `parseRadioShowID`, and `currentHourMs` into `utils.h`/`utils.cpp` as free functions testable on desktop
- Add GoogleTest suite (19 tests) with a minimal Arduino `String` shim
- Add CI workflow (`.github/workflows/test.yml`)

Closes #1

## Test plan

- [x] All 19 tests pass locally (`cd test && cmake -B build && cmake --build build && cd build && ctest --output-on-failure`)
- [x] Refactored callers (`flowsheet_client.cpp`, `.ino`) use the extracted functions
- [ ] CI workflow passes on this PR
- [ ] Verify Arduino sketch still compiles in Arduino IDE (manual -- `utils.h`/`utils.cpp` are auto-included as part of the sketch)