### PR TITLE
Auto DJ Phase B.1: DI refactor + mock-based desktop tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,19 @@ To rotate the API key, update both:
 
 ## Running Tests
 
-Pure logic functions are extracted into testable modules and tested on desktop using GoogleTest with a minimal Arduino `String` shim. No Arduino hardware or SDK required.
+Sketch modules are tested on desktop using GoogleTest with an Arduino shim layer. No Arduino hardware or SDK required. The shim provides `String`, `Print`, `Stream`, `Client`, GPIO stubs, and controllable `millis()`. Real ArduinoHttpClient and ArduinoJson libraries are compiled against the shim via CMake FetchContent.
 
-- **`utils.h`/`utils.cpp`** -- `urlEncode`, `parseRadioShowID`, `currentHourMs`
-- **`state_machine.h`/`state_machine.cpp`** -- `tick()` (state transitions, retry logic, polling decisions)
+**82 tests** cover:
 
-The state machine `tick()` function is a pure function: it takes a `Context` (persisted state) and `Inputs` (sensor snapshot + I/O results) and returns a `TickResult` (updated context + actions for the orchestrator). The `.ino` `loop()` is a thin orchestrator that performs I/O and delegates all decision logic to `tick()`.
+| Module | Tests | Technique |
+|--------|-------|-----------|
+| `utils.h` | 19 | Pure functions (urlEncode, parseRadioShowID, currentHourMs) |
+| `state_machine.h` | 32 | Pure function tick(): state transitions, retries, WiFi loss |
+| `relay_monitor.h` | 12 | Parameterized `update(millis, reading)` bypasses GPIO |
+| `azuracast_client.h` | 9 | `poll(Client&)` with FakeClient pre-loaded HTTP/JSON responses |
+| `flowsheet_client.h` | 10 | `Client&` injection, request body assertions, 302/500 handling |
+
+The I/O modules use dependency injection: `Client&` parameters replace hardcoded `WiFiSSLClient` creation, and `RelayMonitor::update(millis, reading)` replaces `digitalRead()`/`millis()` calls. The `.ino` orchestrator creates `WiFiSSLClient` at each call site and passes it in.
 
 ```bash
 cmake -B test/build test/

--- a/auto-dj-arduino-switch/auto-dj-arduino-switch.ino
+++ b/auto-dj-arduino-switch/auto-dj-arduino-switch.ino
@@ -23,6 +23,7 @@
 #include "flowsheet_client.h"
 #include "utils.h"
 #include "state_machine.h"
+#include <WiFiSSLClient.h>
 
 // ========== Global State ==========
 
@@ -114,22 +115,26 @@ void loop() {
         case STARTING_SHOW: {
             unsigned long hourMs = currentHourMs(inputs.epochTime);
             if (hourMs > 0) {
-                inputs.startShowResult = flowsheet.startShow(hourMs);
+                WiFiSSLClient ssl;
+                inputs.startShowResult = flowsheet.startShow(ssl, hourMs);
             }
             break;
         }
         case AUTO_DJ_ACTIVE:
             if (inputs.currentMillis - ctx.lastPollTime >= POLL_INTERVAL_MS) {
-                inputs.pollNewTrack = azuracast.poll();
+                WiFiSSLClient ssl;
+                inputs.pollNewTrack = azuracast.poll(ssl);
                 inputs.pollLiveDJ = azuracast.isLiveDJ();
                 inputs.artist = azuracast.getArtist();
                 inputs.title = azuracast.getTitle();
                 inputs.album = azuracast.getAlbum();
             }
             break;
-        case ENDING_SHOW:
-            inputs.endShowResult = flowsheet.endShow(ctx.radioShowID);
+        case ENDING_SHOW: {
+            WiFiSSLClient ssl;
+            inputs.endShowResult = flowsheet.endShow(ssl, ctx.radioShowID);
             break;
+        }
         default:
             break;
     }
@@ -142,7 +147,8 @@ void loop() {
 
     // ---- POST-TICK I/O ----
     if (result.addEntry) {
-        flowsheet.addEntry(ctx.radioShowID, result.addEntryHourMs,
+        WiFiSSLClient ssl;
+        flowsheet.addEntry(ssl, ctx.radioShowID, result.addEntryHourMs,
             result.addEntryArtist, result.addEntryTitle, result.addEntryAlbum);
     }
     if (result.delayMs > 0) {

--- a/auto-dj-arduino-switch/azuracast_client.cpp
+++ b/auto-dj-arduino-switch/azuracast_client.cpp
@@ -1,10 +1,14 @@
 #include "azuracast_client.h"
 #include "config.h"
 
+#ifndef DESKTOP_TEST
 #include <WiFi.h>
 #include <WiFiSSLClient.h>
+#endif
+
 #include <ArduinoHttpClient.h>
 #include <ArduinoJson.h>
+#include <Client.h>
 
 AzuraCastClient::AzuraCastClient(const char* host, int port, const char* path)
     : host(host)
@@ -15,11 +19,8 @@ AzuraCastClient::AzuraCastClient(const char* host, int port, const char* path)
 {
 }
 
-bool AzuraCastClient::poll() {
-    // Create SSL client locally to avoid the Giga R1 global WiFiClient crash bug.
-    // Must call stop() before going out of scope to prevent socket leak.
-    WiFiSSLClient ssl;
-    HttpClient http(ssl, host, port);
+bool AzuraCastClient::poll(Client& client) {
+    HttpClient http(client, host, port);
     http.setHttpResponseTimeout(HTTP_RESPONSE_TIMEOUT_MS);
 
     Serial.print("[AzuraCast] Polling...");
@@ -50,11 +51,14 @@ bool AzuraCastClient::poll() {
     filter["now_playing"]["song"]["album"] = true;
     filter["live"]["is_live"] = true;
 
-    JsonDocument doc;
-    DeserializationError jsonErr = deserializeJson(doc, http.responseStream(),
-        DeserializationOption::Filter(filter));
-
+    // Read body as String, then parse with filter. HttpClient does not extend
+    // Stream, so we buffer the body rather than streaming directly.
+    String body = http.responseBody();
     http.stop();
+
+    JsonDocument doc;
+    DeserializationError jsonErr = deserializeJson(doc, body,
+        DeserializationOption::Filter(filter));
 
     if (jsonErr) {
         Serial.print(" JSON parse error: ");
@@ -88,6 +92,15 @@ bool AzuraCastClient::poll() {
 
     return true;
 }
+
+#ifndef DESKTOP_TEST
+bool AzuraCastClient::poll() {
+    // Create SSL client locally to avoid the Giga R1 global WiFiClient crash
+    // bug. Must call stop() before going out of scope to prevent socket leak.
+    WiFiSSLClient ssl;
+    return poll(ssl);
+}
+#endif
 
 String AzuraCastClient::getArtist() const { return artist; }
 String AzuraCastClient::getTitle() const { return title; }

--- a/auto-dj-arduino-switch/azuracast_client.h
+++ b/auto-dj-arduino-switch/azuracast_client.h
@@ -3,6 +3,8 @@
 
 #include <Arduino.h>
 
+class Client; // Forward declaration for Client& parameter
+
 /**
  * Polls the AzuraCast now-playing API and detects track changes.
  *
@@ -19,11 +21,18 @@ public:
     AzuraCastClient(const char* host, int port, const char* path);
 
     /**
-     * Polls the AzuraCast API. Returns true if a new track is detected.
-     * Creates and destroys the SSL client within the call to avoid
-     * the Giga R1 global WiFiClient crash bug.
+     * Polls the AzuraCast API using the given Client. Returns true if a new
+     * track is detected. The caller owns the Client's lifecycle.
+     */
+    bool poll(Client& client);
+
+#ifndef DESKTOP_TEST
+    /**
+     * Hardware convenience wrapper: creates a WiFiSSLClient internally.
+     * Only available on Arduino (excluded from desktop builds).
      */
     bool poll();
+#endif
 
     String getArtist() const;
     String getTitle() const;

--- a/auto-dj-arduino-switch/flowsheet_client.cpp
+++ b/auto-dj-arduino-switch/flowsheet_client.cpp
@@ -2,8 +2,6 @@
 #include "config.h"
 #include "utils.h"
 
-#include <WiFi.h>
-#include <WiFiSSLClient.h>
 #include <ArduinoHttpClient.h>
 
 FlowsheetClient::FlowsheetClient(const char* host, int port, const char* apiKey)
@@ -19,9 +17,8 @@ FlowsheetClient::FlowsheetClient(const char* host, int port, const char* apiKey)
  * POSTs a form-encoded body and returns the HTTP status code, or -1 on error.
  * Fully reads the response body and stops the client to prevent socket leaks.
  */
-int FlowsheetClient::postForm(const char* path, const String& body) {
-    WiFiSSLClient ssl;
-    HttpClient http(ssl, host, port);
+int FlowsheetClient::postForm(Client& client, const char* path, const String& body) {
+    HttpClient http(client, host, port);
     http.setHttpResponseTimeout(HTTP_RESPONSE_TIMEOUT_MS);
 
     http.beginRequest();
@@ -43,9 +40,8 @@ int FlowsheetClient::postForm(const char* path, const String& body) {
  * POSTs a form-encoded body and returns the Location header from a 302 redirect.
  * Returns empty string on failure.
  */
-String FlowsheetClient::getLocationHeader(const char* path, const String& body) {
-    WiFiSSLClient ssl;
-    HttpClient http(ssl, host, port);
+String FlowsheetClient::getLocationHeader(Client& client, const char* path, const String& body) {
+    HttpClient http(client, host, port);
     http.setHttpResponseTimeout(HTTP_RESPONSE_TIMEOUT_MS);
 
     http.beginRequest();
@@ -83,7 +79,7 @@ String FlowsheetClient::getLocationHeader(const char* path, const String& body) 
 
 // ========== Public API ==========
 
-int FlowsheetClient::startShow(unsigned long startingHourMs) {
+int FlowsheetClient::startShow(Client& client, unsigned long startingHourMs) {
     Serial.println("[Flowsheet] Starting show...");
 
     String body = "djID=" + String(AUTO_DJ_ID)
@@ -92,7 +88,7 @@ int FlowsheetClient::startShow(unsigned long startingHourMs) {
         + "&showName=" + urlEncode(AUTO_DJ_SHOW_NAME)
         + "&startingHour=" + String(startingHourMs);
 
-    String location = getLocationHeader(TUBAFRENZY_PATH_START_SHOW, body);
+    String location = getLocationHeader(client, TUBAFRENZY_PATH_START_SHOW, body);
     if (location.length() == 0) {
         Serial.println("[Flowsheet] Failed to start show (no Location header).");
         return -1;
@@ -110,7 +106,7 @@ int FlowsheetClient::startShow(unsigned long startingHourMs) {
     return radioShowID;
 }
 
-bool FlowsheetClient::addEntry(int radioShowID, unsigned long workingHourMs,
+bool FlowsheetClient::addEntry(Client& client, int radioShowID, unsigned long workingHourMs,
                                 const String& artist, const String& title,
                                 const String& album) {
     Serial.print("[Flowsheet] Adding entry: ");
@@ -126,7 +122,7 @@ bool FlowsheetClient::addEntry(int radioShowID, unsigned long workingHourMs,
         + "&releaseType=otherRelease"
         + "&autoBreakpoint=true";
 
-    int status = postForm(TUBAFRENZY_PATH_ADD_ENTRY, body);
+    int status = postForm(client, TUBAFRENZY_PATH_ADD_ENTRY, body);
     if (status == 302) {
         Serial.println("[Flowsheet] Entry added.");
         return true;
@@ -137,13 +133,13 @@ bool FlowsheetClient::addEntry(int radioShowID, unsigned long workingHourMs,
     return false;
 }
 
-bool FlowsheetClient::endShow(int radioShowID) {
+bool FlowsheetClient::endShow(Client& client, int radioShowID) {
     Serial.println("[Flowsheet] Ending show...");
 
     String body = "radioShowID=" + String(radioShowID)
         + "&mode=signoffConfirm";
 
-    int status = postForm(TUBAFRENZY_PATH_END_SHOW, body);
+    int status = postForm(client, TUBAFRENZY_PATH_END_SHOW, body);
     if (status == 302) {
         Serial.print("[Flowsheet] Show ended, radioShowID=");
         Serial.println(radioShowID);

--- a/auto-dj-arduino-switch/flowsheet_client.h
+++ b/auto-dj-arduino-switch/flowsheet_client.h
@@ -2,6 +2,7 @@
 #define FLOWSHEET_CLIENT_H
 
 #include <Arduino.h>
+#include <Client.h>
 
 /**
  * Manages HTTP POST calls to the tubafrenzy flowsheet API.
@@ -12,6 +13,9 @@
  * The servlets respond with HTTP 302 redirects on success. ArduinoHttpClient
  * does not follow redirects by default, so we read the Location header
  * directly (needed for extracting radioShowID from startRadioShow).
+ *
+ * The caller provides a Client& for each operation. On Arduino, this is
+ * typically a WiFiSSLClient created at the call site.
  */
 class FlowsheetClient {
 public:
@@ -21,28 +25,28 @@ public:
      * Starts a new radio show. Returns the radioShowID on success, or -1 on failure.
      * Parses the radioShowID from the Location header of the 302 redirect.
      */
-    int startShow(unsigned long startingHourMs);
+    int startShow(Client& client, unsigned long startingHourMs);
 
     /**
      * Adds a flowsheet entry with autoBreakpoint=true (server handles hourly
      * breakpoints automatically via FlowsheetEntryService.createEntryWithAutoBreakpoints()).
      */
-    bool addEntry(int radioShowID, unsigned long workingHourMs,
+    bool addEntry(Client& client, int radioShowID, unsigned long workingHourMs,
                   const String& artist, const String& title, const String& album);
 
     /**
      * Ends the radio show. Uses mode=signoffConfirm to skip the interactive JSP
      * confirmation page.
      */
-    bool endShow(int radioShowID);
+    bool endShow(Client& client, int radioShowID);
 
 private:
     const char* host;
     int port;
     const char* apiKey;
 
-    int postForm(const char* path, const String& body);
-    String getLocationHeader(const char* path, const String& body);
+    int postForm(Client& client, const char* path, const String& body);
+    String getLocationHeader(Client& client, const char* path, const String& body);
 };
 
 #endif

--- a/auto-dj-arduino-switch/relay_monitor.cpp
+++ b/auto-dj-arduino-switch/relay_monitor.cpp
@@ -8,6 +8,7 @@ RelayMonitor::RelayMonitor(int relayPin, int ledPin, unsigned long debounceMs)
     , lastReading(HIGH)
     , lastChangeTime(0)
     , changed(false)
+    , ledState(LOW)
 {
 }
 
@@ -16,27 +17,32 @@ void RelayMonitor::setUp() {
     pinMode(ledPin, OUTPUT);
     debouncedState = digitalRead(relayPin);
     lastReading = debouncedState;
-    digitalWrite(ledPin, debouncedState == LOW ? HIGH : LOW);
+    ledState = debouncedState == LOW ? HIGH : LOW;
+    digitalWrite(ledPin, ledState);
 }
 
 void RelayMonitor::update() {
-    changed = false;
-    int reading = digitalRead(relayPin);
+    update(millis(), digitalRead(relayPin));
+    digitalWrite(ledPin, ledState);
+}
 
-    if (reading != lastReading) {
-        lastChangeTime = millis();
+void RelayMonitor::update(unsigned long currentMillis, int currentReading) {
+    changed = false;
+
+    if (currentReading != lastReading) {
+        lastChangeTime = currentMillis;
     }
 
-    if ((millis() - lastChangeTime) > debounceMs) {
-        if (reading != debouncedState) {
-            debouncedState = reading;
+    if ((currentMillis - lastChangeTime) > debounceMs) {
+        if (currentReading != debouncedState) {
+            debouncedState = currentReading;
             changed = true;
             // LED on when auto DJ is active (relay closed = LOW)
-            digitalWrite(ledPin, debouncedState == LOW ? HIGH : LOW);
+            ledState = debouncedState == LOW ? HIGH : LOW;
         }
     }
 
-    lastReading = reading;
+    lastReading = currentReading;
 }
 
 bool RelayMonitor::isAutoDJActive() const {
@@ -46,4 +52,8 @@ bool RelayMonitor::isAutoDJActive() const {
 
 bool RelayMonitor::stateChanged() const {
     return changed;
+}
+
+int RelayMonitor::getLedState() const {
+    return ledState;
 }

--- a/auto-dj-arduino-switch/relay_monitor.h
+++ b/auto-dj-arduino-switch/relay_monitor.h
@@ -17,9 +17,20 @@ class RelayMonitor {
 public:
     RelayMonitor(int relayPin, int ledPin, unsigned long debounceMs);
     void setUp();
+
+    /** Hardware wrapper: reads relay pin, runs debounce, writes LED pin. */
     void update();
+
+    /**
+     * Parameterized update for desktop testing. Contains all debounce logic
+     * with no hardware dependencies -- updates debouncedState, changed,
+     * lastReading, lastChangeTime, and ledState based on passed-in values.
+     */
+    void update(unsigned long currentMillis, int currentReading);
+
     bool isAutoDJActive() const;
     bool stateChanged() const;
+    int getLedState() const;
 
 private:
     int relayPin;
@@ -30,6 +41,7 @@ private:
     int lastReading;
     unsigned long lastChangeTime;
     bool changed;
+    int ledState;
 };
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
+cmake_policy(SET CMP0169 OLD)
 project(auto-dj-arduino-switch-tests LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# GoogleTest
 include(FetchContent)
+
+# GoogleTest
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
@@ -13,21 +15,108 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(googletest)
 
-# Build sketch pure-logic sources, using our shim instead of real Arduino.h
+# ArduinoJson v7 (header-only; no CMakeLists.txt integration needed)
+FetchContent_Declare(
+    arduinojson
+    GIT_REPOSITORY https://github.com/bblanchon/ArduinoJson.git
+    GIT_TAG v7.1.0
+)
+FetchContent_GetProperties(arduinojson)
+if(NOT arduinojson_POPULATED)
+    FetchContent_Populate(arduinojson)
+endif()
+
+# ArduinoHttpClient (no CMakeLists.txt -- Arduino library)
+FetchContent_Declare(
+    arduinohttpclient
+    GIT_REPOSITORY https://github.com/arduino-libraries/ArduinoHttpClient.git
+    GIT_TAG 0.6.1
+)
+FetchContent_GetProperties(arduinohttpclient)
+if(NOT arduinohttpclient_POPULATED)
+    FetchContent_Populate(arduinohttpclient)
+endif()
+
+# ========== Sketch source directory ==========
+
 set(SKETCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../auto-dj-arduino-switch)
 
+# ========== Shim & third-party libraries ==========
+
+# Arduino shim (Serial instance, millis(), Stream methods)
+add_library(arduino_shim STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim/shim.cpp
+)
+target_include_directories(arduino_shim PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim
+)
+
+# ArduinoHttpClient compiled against our shim
+add_library(httpclient STATIC
+    ${arduinohttpclient_SOURCE_DIR}/src/HttpClient.cpp
+    ${arduinohttpclient_SOURCE_DIR}/src/b64.cpp
+)
+target_include_directories(httpclient PUBLIC
+    ${arduinohttpclient_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim
+)
+target_link_libraries(httpclient PUBLIC arduino_shim)
+
+# ========== Sketch module libraries ==========
+
+# Pure logic (utils, state_machine) -- no I/O dependencies
 add_library(sketch_logic STATIC
     ${SKETCH_DIR}/utils.cpp
     ${SKETCH_DIR}/state_machine.cpp
 )
 target_include_directories(sketch_logic PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/shim   # Arduino.h shim
-    ${SKETCH_DIR}                       # utils.h, state_machine.h
+    ${SKETCH_DIR}                       # utils.h, state_machine.h, config.h
 )
+
+# Relay monitor module
+add_library(relay_monitor STATIC
+    ${SKETCH_DIR}/relay_monitor.cpp
+)
+target_include_directories(relay_monitor PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim
+    ${SKETCH_DIR}
+)
+target_compile_definitions(relay_monitor PRIVATE DESKTOP_TEST)
+target_link_libraries(relay_monitor PUBLIC arduino_shim)
+
+# AzuraCast client module
+add_library(azuracast_client STATIC
+    ${SKETCH_DIR}/azuracast_client.cpp
+)
+target_include_directories(azuracast_client PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim
+    ${SKETCH_DIR}
+    ${arduinojson_SOURCE_DIR}/src
+)
+target_compile_definitions(azuracast_client PRIVATE
+    DESKTOP_TEST
+    ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+    ARDUINOJSON_ENABLE_ARDUINO_STREAM=1
+)
+target_link_libraries(azuracast_client PUBLIC arduino_shim httpclient)
+
+# Flowsheet client module
+add_library(flowsheet_client STATIC
+    ${SKETCH_DIR}/flowsheet_client.cpp
+)
+target_include_directories(flowsheet_client PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shim
+    ${SKETCH_DIR}
+)
+target_compile_definitions(flowsheet_client PRIVATE DESKTOP_TEST)
+target_link_libraries(flowsheet_client PUBLIC arduino_shim httpclient sketch_logic)
+
+# ========== Tests ==========
 
 enable_testing()
 
-# Test executables
+# Existing tests
 add_executable(test_url_encode test_url_encode.cpp)
 target_link_libraries(test_url_encode PRIVATE sketch_logic GTest::gtest_main)
 
@@ -40,8 +129,26 @@ target_link_libraries(test_current_hour_ms PRIVATE sketch_logic GTest::gtest_mai
 add_executable(test_state_machine test_state_machine.cpp)
 target_link_libraries(test_state_machine PRIVATE sketch_logic GTest::gtest_main)
 
+# Module tests
+add_executable(test_relay_monitor test_relay_monitor.cpp)
+target_link_libraries(test_relay_monitor PRIVATE relay_monitor arduino_shim GTest::gtest_main)
+
+add_executable(test_azuracast_client test_azuracast_client.cpp)
+target_link_libraries(test_azuracast_client PRIVATE azuracast_client arduino_shim GTest::gtest_main)
+target_include_directories(test_azuracast_client PRIVATE ${arduinojson_SOURCE_DIR}/src)
+target_compile_definitions(test_azuracast_client PRIVATE
+    ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+    ARDUINOJSON_ENABLE_ARDUINO_STREAM=1
+)
+
+add_executable(test_flowsheet_client test_flowsheet_client.cpp)
+target_link_libraries(test_flowsheet_client PRIVATE flowsheet_client arduino_shim GTest::gtest_main)
+
 include(GoogleTest)
 gtest_discover_tests(test_url_encode)
 gtest_discover_tests(test_location_parsing)
 gtest_discover_tests(test_current_hour_ms)
 gtest_discover_tests(test_state_machine)
+gtest_discover_tests(test_relay_monitor)
+gtest_discover_tests(test_azuracast_client)
+gtest_discover_tests(test_flowsheet_client)

--- a/test/fake_client.h
+++ b/test/fake_client.h
@@ -1,0 +1,101 @@
+/**
+ * FakeClient: a test double for Arduino's Client class.
+ *
+ * Pre-load a complete HTTP response (status line + headers + body).
+ * The real ArduinoHttpClient parses it identically to a network response.
+ * Written bytes (the HTTP request) are captured for assertion.
+ */
+#ifndef FAKE_CLIENT_H
+#define FAKE_CLIENT_H
+
+#include <Arduino.h>
+#include <Client.h>
+#include <string>
+#include <vector>
+
+class FakeClient : public Client {
+public:
+    /**
+     * Pre-load a complete HTTP response. Call before HttpClient.get()/post().
+     *
+     * Example:
+     *   fake.preloadResponse("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
+     */
+    void preloadResponse(const std::string& response) {
+        responseData_.assign(response.begin(), response.end());
+        readPos_ = 0;
+    }
+
+    /** Returns all bytes written by HttpClient (the HTTP request). */
+    std::string getWrittenData() const {
+        return std::string(writtenData_.begin(), writtenData_.end());
+    }
+
+    // ========== Client interface ==========
+
+    int connect(IPAddress, uint16_t) override {
+        connected_ = true;
+        return 1;
+    }
+
+    int connect(const char*, uint16_t) override {
+        connected_ = true;
+        return 1;
+    }
+
+    size_t write(uint8_t b) override {
+        writtenData_.push_back(b);
+        return 1;
+    }
+
+    size_t write(const uint8_t* buf, size_t size) override {
+        writtenData_.insert(writtenData_.end(), buf, buf + size);
+        return size;
+    }
+
+    int available() override {
+        return static_cast<int>(responseData_.size() - readPos_);
+    }
+
+    int read() override {
+        if (readPos_ < responseData_.size()) {
+            return responseData_[readPos_++];
+        }
+        return -1;
+    }
+
+    int read(uint8_t* buf, size_t size) override {
+        size_t bytesRead = 0;
+        while (bytesRead < size && readPos_ < responseData_.size()) {
+            buf[bytesRead++] = responseData_[readPos_++];
+        }
+        return static_cast<int>(bytesRead);
+    }
+
+    int peek() override {
+        if (readPos_ < responseData_.size()) {
+            return responseData_[readPos_];
+        }
+        return -1;
+    }
+
+    void flush() override {}
+
+    void stop() override {
+        connected_ = false;
+    }
+
+    uint8_t connected() override {
+        return connected_ ? 1 : 0;
+    }
+
+    operator bool() override { return connected_; }
+
+private:
+    std::vector<uint8_t> responseData_;
+    size_t readPos_ = 0;
+    std::vector<uint8_t> writtenData_;
+    bool connected_ = false;
+};
+
+#endif // FAKE_CLIENT_H

--- a/test/shim/Arduino.h
+++ b/test/shim/Arduino.h
@@ -1,9 +1,10 @@
 /**
- * Minimal Arduino String shim for desktop testing.
+ * Arduino shim for desktop testing.
  *
- * Implements just enough of the Arduino String class to compile and test
- * the pure functions extracted into utils.h/utils.cpp. This is NOT a
- * complete Arduino compatibility layer -- only the subset used by utils.cpp.
+ * Provides the subset of the Arduino API needed to compile and test
+ * sketch modules (RelayMonitor, AzuraCastClient, FlowsheetClient) on
+ * desktop using GoogleTest. Includes String, Print, Stream, Serial,
+ * GPIO stubs, and timing functions.
  */
 #ifndef ARDUINO_H_SHIM
 #define ARDUINO_H_SHIM
@@ -12,13 +13,39 @@
 #include <cstring>
 #include <cctype>
 #include <cstdio>
+#include <cstdint>
 #include <sstream>
 
+// ========== Constants ==========
+
 #define HEX 16
+#define DEC 10
+#define HIGH 1
+#define LOW 0
+#define INPUT_PULLUP 2
+#define OUTPUT 1
+#define LED_BUILTIN 13
+
+typedef uint8_t byte;
+
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#define max(a, b) ((a) > (b) ? (a) : (b))
+
+// ========== Character helpers ==========
 
 inline bool isAlphaNumeric(char c) {
     return std::isalnum(static_cast<unsigned char>(c));
 }
+
+inline bool isHexadecimalDigit(char c) {
+    return std::isxdigit(static_cast<unsigned char>(c));
+}
+
+inline bool isSpace(char c) {
+    return std::isspace(static_cast<unsigned char>(c));
+}
+
+// ========== String ==========
 
 class String {
 public:
@@ -45,6 +72,8 @@ public:
 
     unsigned int length() const { return static_cast<unsigned int>(data_.size()); }
     char charAt(unsigned int index) const { return data_[index]; }
+    char operator[](unsigned int index) const { return data_[index]; }
+    char& operator[](unsigned int index) { return data_[index]; }
 
     int indexOf(const char* str) const {
         auto pos = data_.find(str);
@@ -72,8 +101,22 @@ public:
         }
     }
 
-    void reserve(unsigned int size) {
+    unsigned char reserve(unsigned int size) {
         data_.reserve(size);
+        return 1;
+    }
+
+    bool concat(char c) {
+        data_ += c;
+        return true;
+    }
+    bool concat(const char* s) {
+        if (s) data_ += s;
+        return true;
+    }
+    bool concat(const String& s) {
+        data_ += s.data_;
+        return true;
     }
 
     bool equalsIgnoreCase(const String& other) const {
@@ -134,5 +177,122 @@ private:
 inline std::ostream& operator<<(std::ostream& os, const String& s) {
     return os << s.c_str();
 }
+
+// ========== Printable ==========
+
+class Print; // forward declaration
+
+class Printable {
+public:
+    virtual ~Printable() {}
+    virtual size_t printTo(Print& p) const = 0;
+};
+
+// ========== Print ==========
+
+class Print {
+public:
+    virtual ~Print() {}
+    virtual size_t write(uint8_t b) = 0;
+
+    virtual size_t write(const uint8_t* buffer, size_t size) {
+        size_t n = 0;
+        while (size--) {
+            if (write(*buffer++)) n++;
+            else break;
+        }
+        return n;
+    }
+
+    size_t write(const char* str) {
+        if (!str) return 0;
+        return write(reinterpret_cast<const uint8_t*>(str), std::strlen(str));
+    }
+
+    size_t print(const char* s) { return write(s); }
+    size_t print(char c) { return write(static_cast<uint8_t>(c)); }
+    size_t print(int n, int = DEC) {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "%d", n);
+        return write(buf);
+    }
+    size_t print(unsigned int n, int = DEC) {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "%u", n);
+        return write(buf);
+    }
+    size_t print(unsigned long n, int = DEC) {
+        char buf[24];
+        std::snprintf(buf, sizeof(buf), "%lu", n);
+        return write(buf);
+    }
+    size_t print(const String& s) { return write(s.c_str()); }
+
+    size_t println() { return write(reinterpret_cast<const uint8_t*>("\r\n"), 2); }
+    size_t println(const char* s) { size_t n = print(s); return n + println(); }
+    size_t println(char c) { size_t n = print(c); return n + println(); }
+    size_t println(int n, int base = DEC) { size_t n2 = print(n, base); return n2 + println(); }
+    size_t println(unsigned long n, int base = DEC) { size_t n2 = print(n, base); return n2 + println(); }
+    size_t println(const String& s) { size_t n = print(s); return n + println(); }
+};
+
+// ========== Stream ==========
+
+class Stream : public Print {
+public:
+    virtual ~Stream() {}
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual int peek() = 0;
+
+    void setTimeout(unsigned long timeout) { _timeout = timeout; }
+    unsigned long getTimeout() const { return _timeout; }
+
+    // Implemented in shim.cpp (depends on millis())
+    int timedRead();
+    String readString();
+
+    size_t readBytes(char* buffer, size_t length) {
+        size_t count = 0;
+        while (count < length) {
+            int c = timedRead();
+            if (c < 0) break;
+            *buffer++ = static_cast<char>(c);
+            count++;
+        }
+        return count;
+    }
+    size_t readBytes(uint8_t* buffer, size_t length) {
+        return readBytes(reinterpret_cast<char*>(buffer), length);
+    }
+
+protected:
+    unsigned long _timeout = 1000;
+};
+
+// ========== Serial ==========
+
+class NullSerial : public Stream {
+public:
+    void begin(unsigned long) {}
+    size_t write(uint8_t) override { return 1; }
+    int available() override { return 0; }
+    int read() override { return -1; }
+    int peek() override { return -1; }
+    operator bool() const { return true; }
+};
+
+extern NullSerial Serial;
+
+// ========== GPIO ==========
+
+inline void pinMode(int, int) {}
+inline int digitalRead(int) { return HIGH; }
+inline void digitalWrite(int, int) {}
+
+// ========== Timing ==========
+
+unsigned long millis();
+inline void delay(unsigned long) {}
 
 #endif // ARDUINO_H_SHIM

--- a/test/shim/Client.h
+++ b/test/shim/Client.h
@@ -1,0 +1,31 @@
+/**
+ * Arduino Client abstract class for desktop testing.
+ *
+ * Mirrors the Arduino core Client class: extends Stream with connection
+ * management and buffered write. FakeClient (test/fake_client.h) provides
+ * a concrete implementation for injecting pre-loaded HTTP responses.
+ */
+#ifndef CLIENT_H_SHIM
+#define CLIENT_H_SHIM
+
+#include <Arduino.h>
+#include "IPAddress.h"
+
+class Client : public Stream {
+public:
+    virtual ~Client() {}
+    virtual int connect(IPAddress ip, uint16_t port) = 0;
+    virtual int connect(const char* host, uint16_t port) = 0;
+    virtual size_t write(uint8_t b) = 0;
+    virtual size_t write(const uint8_t* buf, size_t size) = 0;
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual int read(uint8_t* buf, size_t size) = 0;
+    virtual int peek() = 0;
+    virtual void flush() = 0;
+    virtual void stop() = 0;
+    virtual uint8_t connected() = 0;
+    virtual operator bool() = 0;
+};
+
+#endif // CLIENT_H_SHIM

--- a/test/shim/IPAddress.h
+++ b/test/shim/IPAddress.h
@@ -1,0 +1,20 @@
+/**
+ * Minimal IPAddress stub for desktop testing.
+ *
+ * Only needed because Client.h references IPAddress in the connect() signature.
+ * Our code never connects by IP address.
+ */
+#ifndef IPADDRESS_H_SHIM
+#define IPADDRESS_H_SHIM
+
+#include <cstdint>
+
+class IPAddress {
+public:
+    IPAddress() : _address{0, 0, 0, 0} {}
+    IPAddress(uint8_t a, uint8_t b, uint8_t c, uint8_t d) : _address{a, b, c, d} {}
+private:
+    uint8_t _address[4];
+};
+
+#endif // IPADDRESS_H_SHIM

--- a/test/shim/shim.cpp
+++ b/test/shim/shim.cpp
@@ -1,0 +1,49 @@
+/**
+ * Desktop shim implementations.
+ *
+ * Provides global Serial instance, controllable millis() for tests,
+ * and Stream methods that depend on millis().
+ */
+#include "Arduino.h"
+
+// ========== Serial ==========
+
+NullSerial Serial;
+
+// ========== Timing ==========
+
+static unsigned long g_millis = 0;
+
+unsigned long millis() {
+    return g_millis;
+}
+
+// Test helpers (declared in test_helpers.h)
+void setMillis(unsigned long ms) {
+    g_millis = ms;
+}
+
+void advanceMillis(unsigned long ms) {
+    g_millis += ms;
+}
+
+// ========== Stream ==========
+
+int Stream::timedRead() {
+    unsigned long start = millis();
+    do {
+        int c = read();
+        if (c >= 0) return c;
+    } while (millis() - start < _timeout);
+    return -1;
+}
+
+String Stream::readString() {
+    String ret;
+    int c = timedRead();
+    while (c >= 0) {
+        ret += static_cast<char>(c);
+        c = timedRead();
+    }
+    return ret;
+}

--- a/test/shim/test_helpers.h
+++ b/test/shim/test_helpers.h
@@ -1,0 +1,12 @@
+/**
+ * Test helpers for controlling the desktop shim.
+ *
+ * Include this in test files that need to manipulate millis() time.
+ */
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+void setMillis(unsigned long ms);
+void advanceMillis(unsigned long ms);
+
+#endif // TEST_HELPERS_H

--- a/test/test_azuracast_client.cpp
+++ b/test/test_azuracast_client.cpp
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+#include "azuracast_client.h"
+#include "fake_client.h"
+#include "test_helpers.h"
+#include <string>
+#include <sstream>
+
+// All tests use poll(Client&) with a FakeClient pre-loaded with HTTP responses.
+
+static const char* HOST = "remote.wxyc.org";
+static const int PORT = 443;
+static const char* PATH = "/api/nowplaying_static/main.json";
+
+// ========== Test Helpers ==========
+
+std::string makeAzuraCastResponse(int shId, const char* artist, const char* title,
+                                   const char* album, bool isLive) {
+    std::ostringstream json;
+    json << "{\"now_playing\":{\"sh_id\":" << shId
+         << ",\"song\":{\"artist\":\"" << artist
+         << "\",\"title\":\"" << title
+         << "\",\"album\":\"" << album
+         << "\"}},\"live\":{\"is_live\":" << (isLive ? "true" : "false") << "}}";
+
+    std::string body = json.str();
+    std::ostringstream response;
+    response << "HTTP/1.1 200 OK\r\n"
+             << "Content-Type: application/json\r\n"
+             << "Content-Length: " << body.size() << "\r\n"
+             << "Connection: close\r\n"
+             << "\r\n"
+             << body;
+    return response.str();
+}
+
+std::string makeHttpResponse(int statusCode, const std::string& body) {
+    std::ostringstream response;
+    response << "HTTP/1.1 " << statusCode << " Error\r\n"
+             << "Content-Length: " << body.size() << "\r\n"
+             << "Connection: close\r\n"
+             << "\r\n"
+             << body;
+    return response.str();
+}
+
+// ========== Tests ==========
+
+TEST(AzuraCastClient, NewTrack_ReturnsTrue) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    fake.preloadResponse(makeAzuraCastResponse(42, "Yo La Tengo", "Autumn Sweater", "I Can Hear the Heart Beating as One", false));
+
+    EXPECT_TRUE(client.poll(fake));
+    EXPECT_EQ(client.getShId(), 42);
+}
+
+TEST(AzuraCastClient, SameTrack_ReturnsFalse) {
+    AzuraCastClient client(HOST, PORT, PATH);
+
+    FakeClient fake1;
+    fake1.preloadResponse(makeAzuraCastResponse(42, "Artist", "Title", "Album", false));
+    ASSERT_TRUE(client.poll(fake1));
+
+    FakeClient fake2;
+    fake2.preloadResponse(makeAzuraCastResponse(42, "Artist", "Title", "Album", false));
+    EXPECT_FALSE(client.poll(fake2));
+}
+
+TEST(AzuraCastClient, DifferentTrack_ReturnsTrue) {
+    AzuraCastClient client(HOST, PORT, PATH);
+
+    FakeClient fake1;
+    fake1.preloadResponse(makeAzuraCastResponse(42, "Artist A", "Title A", "Album A", false));
+    ASSERT_TRUE(client.poll(fake1));
+
+    FakeClient fake2;
+    fake2.preloadResponse(makeAzuraCastResponse(43, "Artist B", "Title B", "Album B", false));
+    EXPECT_TRUE(client.poll(fake2));
+}
+
+TEST(AzuraCastClient, ParsesTrackFields) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    fake.preloadResponse(makeAzuraCastResponse(99, "Broadcast", "Echo's Answer", "Tender Buttons", false));
+
+    ASSERT_TRUE(client.poll(fake));
+    EXPECT_EQ(client.getArtist(), "Broadcast");
+    EXPECT_EQ(client.getTitle(), "Echo's Answer");
+    EXPECT_EQ(client.getAlbum(), "Tender Buttons");
+}
+
+TEST(AzuraCastClient, DetectsLiveDJ) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    fake.preloadResponse(makeAzuraCastResponse(10, "Live DJ", "Song", "Album", true));
+
+    ASSERT_TRUE(client.poll(fake));
+    EXPECT_TRUE(client.isLiveDJ());
+}
+
+TEST(AzuraCastClient, HttpNon200_ReturnsFalse) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    fake.preloadResponse(makeHttpResponse(500, "Internal Server Error"));
+
+    EXPECT_FALSE(client.poll(fake));
+}
+
+TEST(AzuraCastClient, MalformedJson_ReturnsFalse) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    std::string body = "not json at all {{{";
+    fake.preloadResponse(makeHttpResponse(200, body));
+
+    EXPECT_FALSE(client.poll(fake));
+}
+
+TEST(AzuraCastClient, MissingShId_ReturnsFalse) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    std::string body = "{\"now_playing\":{\"song\":{\"artist\":\"A\",\"title\":\"T\",\"album\":\"Al\"}},\"live\":{\"is_live\":false}}";
+    fake.preloadResponse(makeHttpResponse(200, body));
+
+    EXPECT_FALSE(client.poll(fake));
+}
+
+TEST(AzuraCastClient, SpecialCharsInTrackData) {
+    AzuraCastClient client(HOST, PORT, PATH);
+    FakeClient fake;
+    // Use JSON escape sequences for special characters
+    std::string body = "{\"now_playing\":{\"sh_id\":77,\"song\":{\"artist\":\"Bj\\u00f6rk\",\"title\":\"Hunter\",\"album\":\"Homogenic\"}},\"live\":{\"is_live\":false}}";
+    fake.preloadResponse(makeHttpResponse(200, body));
+
+    ASSERT_TRUE(client.poll(fake));
+    // ArduinoJson decodes \\u00f6 to the UTF-8 byte sequence for o-umlaut
+    EXPECT_EQ(std::string(client.getArtist().c_str()).substr(0, 2), "Bj");
+    EXPECT_EQ(client.getTitle(), "Hunter");
+}

--- a/test/test_flowsheet_client.cpp
+++ b/test/test_flowsheet_client.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include "flowsheet_client.h"
+#include "fake_client.h"
+#include "test_helpers.h"
+#include <string>
+#include <sstream>
+
+// All tests use Client& injection with FakeClient pre-loaded HTTP responses.
+
+static const char* HOST = "www.wxyc.info";
+static const int PORT = 443;
+static const char* API_KEY = "test-api-key";
+
+// ========== Test Helpers ==========
+
+std::string make302Response(const std::string& location) {
+    std::ostringstream response;
+    response << "HTTP/1.1 302 Found\r\n"
+             << "Location: " << location << "\r\n"
+             << "Content-Length: 0\r\n"
+             << "Connection: close\r\n"
+             << "\r\n";
+    return response.str();
+}
+
+std::string make500Response() {
+    std::string body = "Internal Server Error";
+    std::ostringstream response;
+    response << "HTTP/1.1 500 Internal Server Error\r\n"
+             << "Content-Length: " << body.size() << "\r\n"
+             << "Connection: close\r\n"
+             << "\r\n"
+             << body;
+    return response.str();
+}
+
+std::string make302ResponseNoLocation() {
+    return "HTTP/1.1 302 Found\r\n"
+           "Content-Length: 0\r\n"
+           "Connection: close\r\n"
+           "\r\n";
+}
+
+// ========== startShow Tests ==========
+
+TEST(FlowsheetClient, StartShow_ReturnsShowID) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response(
+        "/playlists/flowsheet?mode=modifyFlowsheet&radioShowID=12345"));
+
+    int result = client.startShow(fake, 1705345200000UL);
+    EXPECT_EQ(result, 12345);
+}
+
+TEST(FlowsheetClient, StartShow_SendsCorrectBody) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response(
+        "/playlists/flowsheet?radioShowID=1"));
+
+    client.startShow(fake, 1705345200000UL);
+
+    std::string request = fake.getWrittenData();
+    EXPECT_NE(request.find("djID=0"), std::string::npos) << request;
+    EXPECT_NE(request.find("djName=Auto+DJ"), std::string::npos) << request;
+    EXPECT_NE(request.find("djHandle=AutoDJ"), std::string::npos) << request;
+    EXPECT_NE(request.find("showName=Auto+DJ"), std::string::npos) << request;
+    EXPECT_NE(request.find("startingHour=1705345200000"), std::string::npos) << request;
+}
+
+TEST(FlowsheetClient, StartShow_Non302_ReturnsNeg1) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make500Response());
+
+    int result = client.startShow(fake, 1705345200000UL);
+    EXPECT_EQ(result, -1);
+}
+
+TEST(FlowsheetClient, StartShow_NoLocation_ReturnsNeg1) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302ResponseNoLocation());
+
+    int result = client.startShow(fake, 1705345200000UL);
+    EXPECT_EQ(result, -1);
+}
+
+// ========== addEntry Tests ==========
+
+TEST(FlowsheetClient, AddEntry_ReturnsTrue_On302) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response("/playlists/flowsheet"));
+
+    bool result = client.addEntry(fake, 12345, 1705345200000UL,
+                                   "Yo La Tengo", "Autumn Sweater",
+                                   "I Can Hear the Heart Beating as One");
+    EXPECT_TRUE(result);
+}
+
+TEST(FlowsheetClient, AddEntry_SendsCorrectBody) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response("/playlists/flowsheet"));
+
+    client.addEntry(fake, 12345, 1705345200000UL,
+                    "Yo La Tengo", "Autumn Sweater",
+                    "I Can Hear the Heart Beating as One");
+
+    std::string request = fake.getWrittenData();
+    EXPECT_NE(request.find("radioShowID=12345"), std::string::npos) << request;
+    EXPECT_NE(request.find("workingHour=1705345200000"), std::string::npos) << request;
+    EXPECT_NE(request.find("artistName=Yo+La+Tengo"), std::string::npos) << request;
+    EXPECT_NE(request.find("songTitle=Autumn+Sweater"), std::string::npos) << request;
+    EXPECT_NE(request.find("releaseType=otherRelease"), std::string::npos) << request;
+    EXPECT_NE(request.find("autoBreakpoint=true"), std::string::npos) << request;
+}
+
+TEST(FlowsheetClient, AddEntry_SendsApiKeyHeader) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response("/playlists/flowsheet"));
+
+    client.addEntry(fake, 1, 0UL, "A", "T", "Al");
+
+    std::string request = fake.getWrittenData();
+    EXPECT_NE(request.find("X-Auto-DJ-Key: test-api-key"), std::string::npos) << request;
+}
+
+TEST(FlowsheetClient, AddEntry_Non302_ReturnsFalse) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make500Response());
+
+    bool result = client.addEntry(fake, 12345, 1705345200000UL,
+                                   "Artist", "Title", "Album");
+    EXPECT_FALSE(result);
+}
+
+// ========== endShow Tests ==========
+
+TEST(FlowsheetClient, EndShow_ReturnsTrue_On302) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response("/playlists/flowsheet"));
+
+    bool result = client.endShow(fake, 12345);
+    EXPECT_TRUE(result);
+}
+
+TEST(FlowsheetClient, EndShow_SendsSignoffConfirm) {
+    FlowsheetClient client(HOST, PORT, API_KEY);
+    FakeClient fake;
+    fake.preloadResponse(make302Response("/playlists/flowsheet"));
+
+    client.endShow(fake, 12345);
+
+    std::string request = fake.getWrittenData();
+    EXPECT_NE(request.find("radioShowID=12345"), std::string::npos) << request;
+    EXPECT_NE(request.find("mode=signoffConfirm"), std::string::npos) << request;
+}

--- a/test/test_relay_monitor.cpp
+++ b/test/test_relay_monitor.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+#include "relay_monitor.h"
+#include "test_helpers.h"
+
+// All tests use the parameterized update(millis, reading) which has zero
+// hardware dependencies. The no-arg update() wrapper only adds
+// digitalRead() input and digitalWrite() output.
+
+static const int RELAY_PIN = 2;
+static const int LED_PIN = 3;
+static const unsigned long DEBOUNCE_MS = 50;
+
+// ========== Helpers ==========
+
+class RelayMonitorTest : public ::testing::Test {
+protected:
+    RelayMonitor monitor{RELAY_PIN, LED_PIN, DEBOUNCE_MS};
+
+    void feedStableReading(int reading, unsigned long startMs, int count) {
+        for (int i = 0; i < count; i++) {
+            monitor.update(startMs + i, reading);
+        }
+    }
+};
+
+// ========== Tests ==========
+
+TEST_F(RelayMonitorTest, InitialState_HighNotActive) {
+    // After construction (before any update): HIGH = relay open = DJ live
+    EXPECT_FALSE(monitor.isAutoDJActive());
+    EXPECT_FALSE(monitor.stateChanged());
+    EXPECT_EQ(monitor.getLedState(), LOW);
+}
+
+TEST_F(RelayMonitorTest, StableHigh_NoChange) {
+    // Many updates with HIGH readings: no state change
+    for (unsigned long t = 0; t < 200; t++) {
+        monitor.update(t, HIGH);
+        EXPECT_FALSE(monitor.stateChanged());
+        EXPECT_FALSE(monitor.isAutoDJActive());
+        EXPECT_EQ(monitor.getLedState(), LOW);
+    }
+}
+
+TEST_F(RelayMonitorTest, TransitionToLow_BeyondDebounce) {
+    // Feed LOW for > debounceMs: stateChanged() fires, isAutoDJActive() true
+    unsigned long t = 0;
+    monitor.update(t, HIGH); // establish initial state
+    t = 100;
+    monitor.update(t, LOW); // first LOW reading, resets timer
+
+    // Feed LOW readings until debounce period passes
+    for (t = 101; t <= 100 + DEBOUNCE_MS; t++) {
+        monitor.update(t, LOW);
+        EXPECT_FALSE(monitor.stateChanged()) << "Should not change at t=" << t;
+    }
+
+    // One more ms beyond debounce -> transition fires
+    monitor.update(100 + DEBOUNCE_MS + 1, LOW);
+    EXPECT_TRUE(monitor.stateChanged());
+    EXPECT_TRUE(monitor.isAutoDJActive());
+}
+
+TEST_F(RelayMonitorTest, BounceRejected_WithinDebounce) {
+    // LOW then HIGH within debounce window: state stays HIGH
+    monitor.update(0, HIGH);
+    monitor.update(100, LOW);  // start debounce timer
+    monitor.update(120, LOW);  // 20ms < 50ms debounce
+    monitor.update(130, HIGH); // bounce back to HIGH within window
+
+    // Continue with HIGH readings past the original debounce period
+    for (unsigned long t = 131; t <= 200; t++) {
+        monitor.update(t, HIGH);
+    }
+
+    EXPECT_FALSE(monitor.isAutoDJActive());
+    EXPECT_FALSE(monitor.stateChanged());
+}
+
+TEST_F(RelayMonitorTest, LedTracksState) {
+    // After LOW transition: getLedState() HIGH. After back to HIGH: getLedState() LOW
+    monitor.update(0, HIGH);
+    EXPECT_EQ(monitor.getLedState(), LOW);
+
+    // Transition to LOW (auto DJ active)
+    monitor.update(100, LOW);
+    monitor.update(100 + DEBOUNCE_MS + 1, LOW);
+    EXPECT_EQ(monitor.getLedState(), HIGH); // LED on
+
+    // Transition back to HIGH (DJ live)
+    monitor.update(300, HIGH);
+    monitor.update(300 + DEBOUNCE_MS + 1, HIGH);
+    EXPECT_EQ(monitor.getLedState(), LOW); // LED off
+}
+
+TEST_F(RelayMonitorTest, ChangedClearsOnNextUpdate) {
+    // After a state change, next update resets changed to false
+    monitor.update(0, HIGH);
+    monitor.update(100, LOW);
+    monitor.update(100 + DEBOUNCE_MS + 1, LOW);
+    EXPECT_TRUE(monitor.stateChanged());
+
+    // Next update clears changed
+    monitor.update(100 + DEBOUNCE_MS + 2, LOW);
+    EXPECT_FALSE(monitor.stateChanged());
+}
+
+TEST_F(RelayMonitorTest, RapidBounce_ThenStable) {
+    // Alternating readings then stable: only transitions after stable period
+    monitor.update(0, HIGH);
+
+    // Rapid bouncing
+    monitor.update(100, LOW);
+    monitor.update(110, HIGH);
+    monitor.update(120, LOW);
+    monitor.update(130, HIGH);
+    monitor.update(140, LOW);
+
+    // None of these should trigger a transition
+    EXPECT_FALSE(monitor.isAutoDJActive());
+
+    // Now hold LOW stable past debounce from last change at t=140
+    for (unsigned long t = 141; t <= 140 + DEBOUNCE_MS; t++) {
+        monitor.update(t, LOW);
+    }
+    monitor.update(140 + DEBOUNCE_MS + 1, LOW);
+    EXPECT_TRUE(monitor.stateChanged());
+    EXPECT_TRUE(monitor.isAutoDJActive());
+}
+
+TEST_F(RelayMonitorTest, TransitionBackToHigh) {
+    // Stable LOW -> stable HIGH: state changes back, isAutoDJActive() false
+    monitor.update(0, HIGH);
+
+    // Transition to LOW
+    monitor.update(100, LOW);
+    monitor.update(100 + DEBOUNCE_MS + 1, LOW);
+    EXPECT_TRUE(monitor.isAutoDJActive());
+
+    // Clear the changed flag
+    monitor.update(200, LOW);
+    EXPECT_FALSE(monitor.stateChanged());
+
+    // Transition back to HIGH
+    monitor.update(300, HIGH);
+    monitor.update(300 + DEBOUNCE_MS + 1, HIGH);
+    EXPECT_TRUE(monitor.stateChanged());
+    EXPECT_FALSE(monitor.isAutoDJActive());
+}
+
+// Parameterized test: transition fires at exactly debounceMs + 1, not at debounceMs
+class DebounceThresholdTest : public ::testing::TestWithParam<unsigned long> {};
+
+TEST_P(DebounceThresholdTest, ExactDebounceThreshold) {
+    unsigned long debounceMs = GetParam();
+    RelayMonitor monitor(RELAY_PIN, LED_PIN, debounceMs);
+
+    monitor.update(0, HIGH);
+    monitor.update(100, LOW); // start timer at t=100
+
+    // At exactly debounceMs after last change: should NOT transition
+    // (condition is > debounceMs, not >=)
+    monitor.update(100 + debounceMs, LOW);
+    EXPECT_FALSE(monitor.stateChanged())
+        << "Should not change at exactly debounceMs=" << debounceMs;
+
+    // One ms later: SHOULD transition
+    monitor.update(100 + debounceMs + 1, LOW);
+    EXPECT_TRUE(monitor.stateChanged())
+        << "Should change at debounceMs+1=" << (debounceMs + 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    VariousDebounceValues,
+    DebounceThresholdTest,
+    ::testing::Values(10UL, 50UL, 100UL, 200UL)
+);


### PR DESCRIPTION
## Summary

- Refactor RelayMonitor, AzuraCastClient, and FlowsheetClient with dependency injection for desktop testability
- Expand Arduino shim with Print/Stream/Client hierarchy; compile real ArduinoHttpClient + ArduinoJson on desktop
- Add FakeClient test helper and 31 new tests (82 total, all passing)

Closes #17

## Test plan

- [x] All 82 desktop tests pass (`cmake -B test/build test/ && cmake --build test/build && cd test/build && ctest --output-on-failure`)
- [x] Existing 51 tests unaffected by shim expansion
- [x] 12 RelayMonitor tests: debounce timing, LED mirroring, bounce rejection, exact threshold
- [x] 9 AzuraCastClient tests: JSON parsing, track change detection, live DJ, error cases
- [x] 10 FlowsheetClient tests: form body construction, API key header, 302/500 handling
- [ ] CI passes (GitHub Actions)
- [ ] Arduino IDE compilation verified (manual: `.ino` compiles with Giga R1 WiFi board)