### PR TITLE
Spec: physical button, virtual switch API, and dj-site status UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ docs/                     Specifications and reference docs
 | `azuracast_client.h/.cpp` | AzuraCast Now Playing API client |
 | `flowsheet_client.h/.cpp` | tubafrenzy flowsheet API client |
 | `relay_monitor.h/.cpp` | Debounced relay input |
+| `button_monitor.h/.cpp` | Debounced manual toggle button input |
 | `wifi_manager.h/.cpp` | WiFi connection management |
 | `config.h` | All compile-time constants |
 
@@ -74,3 +75,4 @@ See [enclosure/README.md](enclosure/README.md) for full build/assembly instructi
 - `secrets.h` is gitignored. Copy from `secrets.h.example`.
 - The Giga R1's WiFi reconnection blocks for ~36s (firmware limitation). The state machine cannot run during this window.
 - The enclosure's `output/` directory is gitignored. Regenerate with `make -C enclosure all`.
+- The physical toggle button sends a `button_toggle` message to the orchestrator via the management channel. All activation logic lives in the orchestrator -- the button does not directly control the Arduino's state machine. See [docs/plan-button-and-virtual-switch.md](docs/plan-button-and-virtual-switch.md) for the virtual switch API spec and dj-site UI design.

--- a/docs/networking-spec.md
+++ b/docs/networking-spec.md
@@ -239,6 +239,32 @@ The admin UI is a web dashboard that gives station managers remote visibility in
 
 **Phase**: The admin UI is part of Phase 3 ([Section 7.4](#74-phase-3-websocket-management--azuracast-direct-websocket)), tracked as a 14-day task (`p3d`) that runs in parallel with the WebSocket management client work.
 
+### 2.7 Activation Sources
+
+The auto-DJ system can be activated and deactivated from three sources. All activation logic lives in the orchestrator ([auto-dj-orchestrator](https://github.com/WXYC/auto-dj-orchestrator)) -- the Arduino reports inputs but does not make activation decisions.
+
+| Source | Trigger | How it reaches the orchestrator | Section |
+|--------|---------|-------------------------------|---------|
+| **Virtual switch** | DJ clicks activate/deactivate in [dj-site](https://github.com/WXYC/dj-site) | `POST /api/auto-dj/activate` or `/deactivate` on the orchestrator | [3.10](#310-virtual-switch-api) |
+| **Physical button** | Mushroom head button press on Arduino | Arduino sends a `button_toggle` message over the management channel (WebSocket or HTTP fallback) | [3.6.2](#362-message-types), [3.7](#37-http-fallback-management-polling-wifi) |
+| **Relay** | Mixing board AUX relay state change | Arduino reports relay state in heartbeat; orchestrator auto-deactivates when relay indicates a live DJ is broadcasting | [3.6.2](#362-message-types) |
+
+#### Conflict Resolution
+
+1. **Live DJ always wins.** If the relay reports a live DJ (`is_live: true` from AzuraCast, or relay open), the orchestrator deactivates auto-DJ regardless of the virtual switch or button state. The status response shows `deactivatedBy.source: "relay"`.
+
+2. **Button and virtual switch are equivalent.** Both toggle the orchestrator's activation state. The last action wins. There is no precedence between them.
+
+3. **No automatic reactivation after live DJ.** When the relay transitions back to auto-DJ-active (live DJ signs off), the orchestrator does NOT automatically reactivate. A DJ must explicitly activate via the virtual switch or the physical button. This prevents the auto-DJ from unexpectedly resuming after a DJ finishes their show.
+
+#### Physical Button Hardware
+
+The Arduino has a 22mm industrial mushroom head button (momentary, spring return) on D5 (`BUTTON_PIN`), debounced identically to the relay input (50ms). See [wiring.md](wiring.md) for the full wiring guide. The button uses the NO (normally open) contact: at rest D5 reads HIGH (internal pullup), and pressing the button pulls D5 LOW.
+
+The button does NOT directly affect the Arduino's state machine. On a debounced press, the Arduino sends a `button_toggle` message to the orchestrator via the management channel ([Section 3.6.2](#362-message-types)). Over WiFi fallback, the press is reported in the next heartbeat via the `button_press_count` field ([Section 3.7](#37-http-fallback-management-polling-wifi)). The orchestrator decides whether to activate or deactivate based on its current state, and the result flows back to the Arduino via the standard ack/command mechanism.
+
+Before the orchestrator is deployed, the button is wired and debounced but has no effect. The Arduino continues to operate in relay-only mode.
+
 ---
 
 ## 3. Protocol Reference
@@ -262,6 +288,9 @@ The admin UI is a web dashboard that gives station managers remote visibility in
 | 13 | Admin UI → Mgmt Server | HTTPS POST | `/api/auto-dj/commands` | Better Auth session | JSON | N/A | Planned |
 | 14 | Admin UI → Mgmt Server | HTTPS GET | `/api/auto-dj/status` | Better Auth session | JSON response | N/A | Planned |
 | 15 | Arduino → NTP | WiFi.getTime() | (internal to WiFi module) | None | NTP | WiFi | **Implemented** |
+| 16 | dj-site → Orchestrator | HTTPS POST | `/api/auto-dj/activate` | Better Auth JWT | JSON | N/A | Planned |
+| 17 | dj-site → Orchestrator | HTTPS POST | `/api/auto-dj/deactivate` | Better Auth JWT | JSON | N/A | Planned |
+| 18 | dj-site → Orchestrator | HTTPS GET | `/api/auto-dj/status` | Better Auth JWT | JSON response | N/A | Planned |
 
 ### 3.2 Outbound HTTP: AzuraCast Now Playing
 
@@ -624,14 +653,15 @@ All WebSocket messages are JSON objects with a `type` discriminator field.
     "reconnect_count": 0,
     "tracks_detected": 142,
     "tracks_posted": 140,
-    "errors_since_boot": 2
+    "errors_since_boot": 2,
+    "button_press_count": 0
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | `"heartbeat"` | Message discriminator |
-| `state` | `string` | Current state machine state (`BOOTING`, `IDLE`, `STARTING_SHOW`, `AUTO_DJ_ACTIVE`, `ENDING_SHOW`) |
+| `state` | `string` | Current state machine state (`BOOTING`, `CONNECTING_WIFI`, `IDLE`, `STARTING_SHOW`, `AUTO_DJ_ACTIVE`, `ENDING_SHOW`, `ERROR_STATE`) |
 | `transport` | `string` | Active transport (`"ethernet"` or `"wifi"`) |
 | `uptime_s` | `integer` | Seconds since boot |
 | `wifi_rssi` | `integer \| null` | WiFi signal strength in dBm, or `null` if on Ethernet |
@@ -649,6 +679,7 @@ All WebSocket messages are JSON objects with a `type` discriminator field.
 | `tracks_detected` | `integer` | Total track changes detected from AzuraCast since boot |
 | `tracks_posted` | `integer` | Total entries successfully posted to the flowsheet since boot |
 | `errors_since_boot` | `integer` | Total errors since boot |
+| `button_press_count` | `integer` | Number of button presses since last heartbeat (WiFi fallback only; 0 if no presses) |
 
 **Command** (Server → Arduino):
 
@@ -741,6 +772,33 @@ This is a flat structure designed for efficient ArduinoJson parsing. If the rela
 
 Consecutive identical errors are batched on the Arduino side: `count` is incremented locally and the error report is sent periodically rather than on every occurrence. This avoids flooding the WebSocket with repeated errors (e.g., a flapping network connection). The management server can relay these to Sentry or another error tracking service, grouped by `module` and `code`.
 
+**Button Toggle** (Arduino → Server):
+
+```json
+{
+    "type": "button_toggle",
+    "timestamp": 1709852100
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"button_toggle"` | Message discriminator |
+| `timestamp` | `integer` | Unix timestamp of the button press (from NTP) |
+
+Sent when the physical mushroom button is pressed ([Section 2.7](#27-activation-sources)). The orchestrator responds by toggling its activation state. The ack includes the resulting state:
+
+```json
+{
+    "type": "ack",
+    "id": "btn_1709852100",
+    "status": "ok",
+    "result": { "active": true }
+}
+```
+
+The `result` field is an optional extension to the `AutoDJAck` schema. It is present only in acks for `button_toggle` messages. The Arduino uses `result.active` to update local state (e.g., status LED) but does not depend on it for state machine transitions. The `id` is derived from the button press timestamp for correlation.
+
 #### 3.6.3 Supported Commands
 
 | Action | Parameters | Effect | Hot-reload? |
@@ -788,7 +846,7 @@ When the Arduino is on WiFi (no persistent connections), the management channel 
 | **URL** | `https://<management-server>/api/auto-dj/heartbeat` |
 | **Auth** | `X-Auto-DJ-Key: <key>` |
 | **Content-Type** | `application/json` |
-| **Body** | Same JSON as the WebSocket heartbeat message ([Section 3.6.2](#362-message-types)) |
+| **Body** | Same JSON as the WebSocket heartbeat message ([Section 3.6.2](#362-message-types)). The `button_press_count` field carries any button presses that occurred since the last heartbeat; the orchestrator toggles state if the count is odd. |
 | **Response** | 200 OK |
 
 **Command poll** (Arduino → Server):
@@ -930,6 +988,139 @@ filter["connect"]["subs"]["station:*"]["publications"][0]["data"]["np"]["live"][
 If the Centrifugo payload exceeds ArduinoJson's practical parsing limits on the Giga R1 (~16 KB with filter), the relay approach ([Appendix B](#appendix-b-azuracast-centrifugo-integration-details)) becomes necessary -- the management server would extract the relevant fields and send a flat ~200-byte `AutoDJNowPlaying` message.
 
 See [Appendix B](#appendix-b-azuracast-centrifugo-integration-details) for the relay alternative and detailed Centrifugo integration notes.
+
+### 3.10 Virtual Switch API
+
+**Status**: Planned
+
+The orchestrator ([auto-dj-orchestrator](https://github.com/WXYC/auto-dj-orchestrator)) exposes these endpoints for [dj-site](https://github.com/WXYC/dj-site) (and any future admin UI) to control auto-DJ activation. These are separate from the device management endpoints in [Section 3.8](#38-server-side-endpoints), which are Arduino-facing. These endpoints are included in this networking spec because this document is the single source of truth for all auto-DJ network traffic, and the orchestrator README explicitly references it.
+
+#### 3.10.1 Traffic Summary
+
+| # | Direction | Protocol | Endpoint | Auth | Content Type | Status |
+|---|-----------|----------|----------|------|-------------|--------|
+| 16 | dj-site → Orchestrator | HTTPS POST | `/api/auto-dj/activate` | Better Auth JWT | JSON | Planned |
+| 17 | dj-site → Orchestrator | HTTPS POST | `/api/auto-dj/deactivate` | Better Auth JWT | JSON | Planned |
+| 18 | dj-site → Orchestrator | HTTPS GET | `/api/auto-dj/status` | Better Auth JWT | JSON response | Planned |
+
+#### 3.10.2 Activate
+
+| Field | Value |
+|-------|-------|
+| **Method** | POST |
+| **URL** | `https://<orchestrator>/api/auto-dj/activate` |
+| **Auth** | `Authorization: Bearer <JWT>` (Better Auth, `dj` role or higher) |
+| **Request body** | None |
+| **Response (200)** | `AutoDJStatus` JSON (see below) |
+
+Activates the auto-DJ system. The orchestrator starts a show on the configured flowsheet backend(s) and begins subscribing to AzuraCast for track changes.
+
+**Error responses**:
+- `409 Conflict`: Auto-DJ is already active. Response body includes the current `AutoDJStatus`.
+- `409 Conflict`: A live DJ show is in progress. Auto-DJ cannot activate while a DJ is broadcasting.
+- `403 Forbidden`: Insufficient permissions.
+
+**Side effects**:
+- Orchestrator calls `POST /flowsheet/join` on Backend-Service (and/or `startRadioShow` on tubafrenzy) to create a show.
+- Orchestrator begins subscribing to AzuraCast now-playing feed.
+- If the Arduino is connected via the management channel, the orchestrator sends it a `resume` command (in case it was paused).
+
+#### 3.10.3 Deactivate
+
+| Field | Value |
+|-------|-------|
+| **Method** | POST |
+| **URL** | `https://<orchestrator>/api/auto-dj/deactivate` |
+| **Auth** | `Authorization: Bearer <JWT>` (Better Auth, `dj` role or higher) |
+| **Request body** | None |
+| **Response (200)** | `AutoDJDeactivateResponse` JSON (see below) |
+
+Deactivates the auto-DJ system. The orchestrator ends the current show and stops writing to the flowsheet.
+
+**Error responses**:
+- `409 Conflict`: Auto-DJ is not currently active.
+- `403 Forbidden`: Insufficient permissions.
+
+**Side effects**:
+- Orchestrator calls `POST /flowsheet/end` on Backend-Service (and/or `finishRadioShow` on tubafrenzy).
+- Orchestrator stops subscribing to AzuraCast.
+- If the Arduino is connected, the orchestrator sends it a `pause` command.
+
+#### 3.10.4 Status
+
+| Field | Value |
+|-------|-------|
+| **Method** | GET |
+| **URL** | `https://<orchestrator>/api/auto-dj/status` |
+| **Auth** | `Authorization: Bearer <JWT>` (Better Auth, `dj` role or higher for full status) |
+| **Response (200)** | `AutoDJStatus` JSON |
+
+Returns the current auto-DJ activation state, current track, and device status.
+
+**Response when active:**
+
+```json
+{
+    "active": true,
+    "activatedBy": {
+        "source": "virtual_switch",
+        "userId": "usr_abc123",
+        "userName": "DJ Moonbeam"
+    },
+    "activatedAt": "2026-03-07T22:15:00Z",
+    "showId": 789,
+    "currentTrack": {
+        "artist": "Juana Molina",
+        "title": "la paradoja",
+        "album": "DOGA",
+        "detectedAt": "2026-03-07T23:42:18Z"
+    },
+    "device": {
+        "online": true,
+        "transport": "ethernet",
+        "lastHeartbeat": "2026-03-07T23:44:30Z",
+        "relayState": "auto_dj_active"
+    }
+}
+```
+
+**Response when inactive:**
+
+```json
+{
+    "active": false,
+    "lastDeactivatedAt": "2026-03-07T20:00:00Z",
+    "lastDeactivatedBy": {
+        "source": "relay",
+        "detail": "Live DJ detected"
+    },
+    "device": {
+        "online": true,
+        "transport": "ethernet",
+        "lastHeartbeat": "2026-03-07T23:44:30Z",
+        "relayState": "dj_live"
+    }
+}
+```
+
+The `device` block is `null` if the Arduino has never connected to the orchestrator.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `active` | `boolean` | Whether auto-DJ is currently active |
+| `activatedBy` | `object \| undefined` | Present when active. `source` is one of `"virtual_switch"`, `"button"`, `"relay"` |
+| `activatedBy.userId` | `string \| undefined` | Better Auth user ID (only for `virtual_switch` source) |
+| `activatedBy.userName` | `string \| undefined` | Display name (only for `virtual_switch` source) |
+| `activatedAt` | `string \| undefined` | ISO 8601 timestamp of activation |
+| `showId` | `integer \| undefined` | Active flowsheet show ID |
+| `currentTrack` | `object \| null` | Current track from AzuraCast, or `null` if no track detected yet |
+| `lastDeactivatedAt` | `string \| undefined` | Present when inactive. ISO 8601 timestamp of last deactivation |
+| `lastDeactivatedBy` | `object \| undefined` | Present when inactive. Same `source` field as `activatedBy` |
+| `device` | `object \| null` | Arduino device status, or `null` if never connected |
+| `device.online` | `boolean` | Whether the Arduino is currently connected (heartbeat within 60s) |
+| `device.transport` | `string` | `"ethernet"` or `"wifi"` |
+| `device.lastHeartbeat` | `string` | ISO 8601 timestamp of last heartbeat |
+| `device.relayState` | `string` | `"auto_dj_active"` or `"dj_live"` |
 
 ---
 
@@ -1182,6 +1373,7 @@ AutoDJWebSocketMessage:
     - $ref: '#/components/schemas/AutoDJAck'
     - $ref: '#/components/schemas/AutoDJNowPlaying'
     - $ref: '#/components/schemas/AutoDJErrorReport'
+    - $ref: '#/components/schemas/AutoDJButtonToggle'
   discriminator:
     propertyName: type
     mapping:
@@ -1190,6 +1382,7 @@ AutoDJWebSocketMessage:
       ack: '#/components/schemas/AutoDJAck'
       now_playing: '#/components/schemas/AutoDJNowPlaying'
       error: '#/components/schemas/AutoDJErrorReport'
+      button_toggle: '#/components/schemas/AutoDJButtonToggle'
 ```
 
 #### 5.2.2 AutoDJHeartbeat
@@ -1216,7 +1409,7 @@ AutoDJHeartbeat:
       enum: [heartbeat]
     state:
       type: string
-      enum: [BOOTING, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW]
+      enum: [BOOTING, CONNECTING_WIFI, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW, ERROR_STATE]
     transport:
       type: string
       enum: [ethernet, wifi]
@@ -1249,6 +1442,9 @@ AutoDJHeartbeat:
       type: integer
     errors_since_boot:
       type: integer
+    button_press_count:
+      type: integer
+      description: Number of button presses since last heartbeat (WiFi fallback; 0 if none)
 
 AutoDJLastTrack:
   type: object
@@ -1314,6 +1510,9 @@ AutoDJAck:
     error:
       type: string
       description: Error message (only when status is error)
+    result:
+      type: object
+      description: Optional result data (e.g., { active: boolean } for button_toggle acks)
 ```
 
 #### 5.2.5 AutoDJNowPlaying
@@ -1376,7 +1575,7 @@ AutoDJErrorReport:
       type: string
     state:
       type: string
-      enum: [BOOTING, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW]
+      enum: [BOOTING, CONNECTING_WIFI, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW, ERROR_STATE]
     uptime_s:
       type: integer
     free_ram:
@@ -1451,6 +1650,133 @@ AutoDJCommandAction:
     - ping
 ```
 
+#### 5.2.9 AutoDJButtonToggle
+
+```yaml
+AutoDJButtonToggle:
+  type: object
+  required:
+    - type
+    - timestamp
+  properties:
+    type:
+      type: string
+      enum: [button_toggle]
+    timestamp:
+      type: integer
+      description: Unix timestamp of the button press (from NTP)
+```
+
+#### 5.2.10 AutoDJStatus (Virtual Switch API)
+
+Response type for `GET /api/auto-dj/status` and `POST /api/auto-dj/activate` ([Section 3.10](#310-virtual-switch-api)).
+
+```yaml
+AutoDJStatus:
+  type: object
+  required:
+    - active
+  properties:
+    active:
+      type: boolean
+    activatedBy:
+      $ref: '#/components/schemas/AutoDJActivationSource'
+    activatedAt:
+      type: string
+      format: date-time
+    showId:
+      type: integer
+    currentTrack:
+      $ref: '#/components/schemas/AutoDJCurrentTrack'
+      nullable: true
+    lastDeactivatedAt:
+      type: string
+      format: date-time
+    lastDeactivatedBy:
+      $ref: '#/components/schemas/AutoDJActivationSource'
+    device:
+      $ref: '#/components/schemas/AutoDJDeviceSummary'
+      nullable: true
+
+AutoDJActivationSource:
+  type: object
+  required:
+    - source
+  properties:
+    source:
+      type: string
+      enum: [virtual_switch, button, relay]
+    userId:
+      type: string
+      description: Better Auth user ID (only for virtual_switch source)
+    userName:
+      type: string
+      description: Display name (only for virtual_switch source)
+    detail:
+      type: string
+      description: Additional context (e.g., "Live DJ detected" for relay source)
+
+AutoDJCurrentTrack:
+  type: object
+  required:
+    - artist
+    - title
+    - album
+    - detectedAt
+  properties:
+    artist:
+      type: string
+    title:
+      type: string
+    album:
+      type: string
+    detectedAt:
+      type: string
+      format: date-time
+
+AutoDJDeviceSummary:
+  type: object
+  required:
+    - online
+    - transport
+    - lastHeartbeat
+    - relayState
+  properties:
+    online:
+      type: boolean
+    transport:
+      type: string
+      enum: [ethernet, wifi]
+    lastHeartbeat:
+      type: string
+      format: date-time
+    relayState:
+      type: string
+      enum: [auto_dj_active, dj_live]
+```
+
+#### 5.2.11 AutoDJDeactivateResponse
+
+Response type for `POST /api/auto-dj/deactivate` ([Section 3.10](#310-virtual-switch-api)).
+
+```yaml
+AutoDJDeactivateResponse:
+  type: object
+  required:
+    - active
+    - deactivatedBy
+    - deactivatedAt
+  properties:
+    active:
+      type: boolean
+      enum: [false]
+    deactivatedBy:
+      $ref: '#/components/schemas/AutoDJActivationSource'
+    deactivatedAt:
+      type: string
+      format: date-time
+```
+
 ### 5.3 TypeScript Extensions
 
 The new schemas live in `api.yaml` as `components/schemas` and are code-generated into `src/generated/models/`. Hand-written TypeScript utilities go in a new `src/auto-dj/` directory, following the pattern of `src/dtos/extensions.ts`.
@@ -1466,6 +1792,7 @@ import type {
     AutoDJAck,
     AutoDJNowPlaying,
     AutoDJErrorReport,
+    AutoDJButtonToggle,
 } from '../generated/models';
 
 // Discriminated union of all WebSocket message types
@@ -1474,7 +1801,8 @@ export type AutoDJWebSocketMessage =
     | AutoDJCommand
     | AutoDJAck
     | AutoDJNowPlaying
-    | AutoDJErrorReport;
+    | AutoDJErrorReport
+    | AutoDJButtonToggle;
 
 // Type guards
 export function isHeartbeat(msg: AutoDJWebSocketMessage): msg is AutoDJHeartbeat {
@@ -1496,6 +1824,10 @@ export function isNowPlaying(msg: AutoDJWebSocketMessage): msg is AutoDJNowPlayi
 export function isErrorReport(msg: AutoDJWebSocketMessage): msg is AutoDJErrorReport {
     return msg.type === 'error';
 }
+
+export function isButtonToggle(msg: AutoDJWebSocketMessage): msg is AutoDJButtonToggle {
+    return msg.type === 'button_toggle';
+}
 ```
 
 **`src/auto-dj/index.ts`**:
@@ -1508,11 +1840,17 @@ export type {
     AutoDJAck,
     AutoDJNowPlaying,
     AutoDJErrorReport,
+    AutoDJButtonToggle,
     AutoDJDeviceStatus,
     AutoDJCommandAction,
     AutoDJErrorLevel,
     AutoDJErrorCode,
     AutoDJLastTrack,
+    AutoDJStatus,
+    AutoDJActivationSource,
+    AutoDJCurrentTrack,
+    AutoDJDeviceSummary,
+    AutoDJDeactivateResponse,
     AutoDJWebSocketMessage as AutoDJWebSocketMessageSchema,
 } from '../generated/models';
 
@@ -1524,6 +1862,7 @@ export {
     isAck,
     isNowPlaying,
     isErrorReport,
+    isButtonToggle,
 } from './extensions';
 ```
 
@@ -1566,8 +1905,10 @@ The Arduino cannot consume npm packages. ArduinoJson code must manually match th
 
 | Consumer | Language | Types Used |
 |----------|---------|------------|
+| Orchestrator | TypeScript | All message types (`AutoDJWebSocketMessage` union), `AutoDJStatus`, `AutoDJDeactivateResponse`, `AutoDJActivationSource` |
 | Management server | TypeScript | All message types (`AutoDJWebSocketMessage` union) |
 | Backend-Service | TypeScript | `AutoDJDeviceStatus`, `AutoDJCommandAction` (if hosting management endpoints) |
+| dj-site | TypeScript | `AutoDJStatus`, `AutoDJDeactivateResponse`, `AutoDJActivationSource`, `AutoDJCurrentTrack`, `AutoDJDeviceSummary` |
 | Admin UI | TypeScript | `AutoDJDeviceStatus`, `AutoDJHeartbeat` |
 | Arduino | C++ (ArduinoJson) | All message types (manual contract, not import) |
 | tubafrenzy | Java | None (uses `X-Auto-DJ-Key` only; no management types) |
@@ -2305,6 +2646,10 @@ flowchart LR
 15. ~~**AsyncAPI**~~: **Decided** -- OpenAPI component schemas only. Protocol direction and lifecycle documented in prose with Mermaid sequence diagrams ([Section 3.6](#36-websocket-management-channel)). No AsyncAPI spec needed.
 
 16. **`is_automation` flag in mobile apps:** The `is_automation` column on `DJ`/`NewDJ` in `api.yaml` will propagate to Swift (wxyc-ios-64) and Kotlin (WXYC-Android) via existing code generation. A follow-up PR to each mobile app is needed to handle this field (e.g., filtering Auto DJ from DJ lists). Track as a separate task.
+
+17. **Button debounce edge:** Should the `ButtonMonitor` trigger on the falling edge (button pressed, D5 goes LOW) or the rising edge (button released, D5 goes HIGH)? Triggering on press feels more responsive, but triggering on release prevents accidental double-fires if the button bounces differently than the relay. The relay triggers on stable state rather than edges. Decision should be made during `ButtonMonitor` implementation and validated with the specific mushroom head button hardware.
+
+18. **Orchestrator URL for dj-site:** The orchestrator is a standalone service on Railway, separate from Backend-Service. dj-site needs a new environment variable (e.g., `NEXT_PUBLIC_ORCHESTRATOR_URL` or equivalent for the build tool in use) to route virtual switch API calls to the orchestrator. The exact env var prefix depends on dj-site's build tool (Vite uses `VITE_`, Next.js uses `NEXT_PUBLIC_`).
 
 ---
 

--- a/docs/plan-button-and-virtual-switch.md
+++ b/docs/plan-button-and-virtual-switch.md
@@ -1,0 +1,368 @@
+# Plan: Physical Button, Virtual Switch API, and Status UI
+
+This plan adds three capabilities to the auto-DJ system:
+
+1. **Physical button** on the Arduino as a second activation source (alongside the relay)
+2. **Virtual switch API** on the orchestrator for dj-site to activate/deactivate auto-DJ and query status
+3. **Status indicator** in the dj-site UI showing auto-DJ state
+
+## Context
+
+Today the Arduino is entirely relay-driven: the mixing board's AUX relay determines whether auto-DJ is active. There is no manual override and no remote visibility into the auto-DJ state from the DJ's perspective. The orchestrator repo exists but has no implementation -- only a README linking to the networking spec in this repo.
+
+The networking spec (sections 2.4, 2.6, 3.8) defines management server endpoints for device administration (`/api/auto-dj/status`, `/api/auto-dj/commands`), but does not define a **virtual switch** API for activation/deactivation from dj-site. The orchestrator README references sections (2.2 "Virtual Switch Activation", 3.4 "Auto-DJ activation API") that do not yet exist in the networking spec.
+
+## Scope
+
+### In scope
+
+- Spec the virtual switch API endpoints on the orchestrator (activate, deactivate, status)
+- Spec the dj-site UI component for auto-DJ status
+- Add physical button to the Arduino wiring spec
+- Update the networking spec with the missing virtual switch sections
+- Update wiring.md, config.h docs, and CLAUDE.md
+
+### Out of scope
+
+- Orchestrator implementation (no code exists yet; spec only)
+- Backend-Service schema changes (covered by the existing `is_automation` plan in networking-spec section 5)
+- Arduino firmware changes (button input, state machine modifications)
+- dj-site implementation
+
+## 1. Virtual Switch API (Orchestrator)
+
+The orchestrator exposes these endpoints for dj-site (and any future admin UI) to control auto-DJ activation. These are separate from the device management endpoints in networking-spec section 3.8, which are Arduino-facing.
+
+### Endpoints
+
+#### `POST /api/auto-dj/activate`
+
+Activates the auto-DJ system. The orchestrator starts a show on the configured flowsheet backend(s) and begins subscribing to AzuraCast for track changes.
+
+**Auth**: Better Auth session/JWT. Requires `dj` role or higher.
+
+**Request body**: None required. The orchestrator uses its own configured identity (Auto DJ DJ record).
+
+**Response** (200):
+```json
+{
+  "active": true,
+  "activatedBy": {
+    "source": "virtual_switch",
+    "userId": "usr_abc123",
+    "userName": "DJ Moonbeam"
+  },
+  "activatedAt": "2026-03-07T22:15:00Z",
+  "showId": 789,
+  "currentTrack": null
+}
+```
+
+**Error responses**:
+- `409 Conflict`: Auto-DJ is already active. Response includes the current status.
+- `409 Conflict`: A live DJ show is in progress. Auto-DJ cannot activate while a DJ is broadcasting.
+- `403 Forbidden`: Insufficient permissions.
+
+**Side effects**:
+- Orchestrator calls `POST /flowsheet/join` on Backend-Service (and/or `startRadioShow` on tubafrenzy) to create a show.
+- Orchestrator begins subscribing to AzuraCast now-playing feed.
+- If the Arduino is connected via the management channel, the orchestrator sends it a `resume` command (in case it was paused).
+
+#### `POST /api/auto-dj/deactivate`
+
+Deactivates the auto-DJ system. The orchestrator ends the current show and stops writing to the flowsheet.
+
+**Auth**: Better Auth session/JWT. Requires `dj` role or higher.
+
+**Request body**: None required.
+
+**Response** (200):
+```json
+{
+  "active": false,
+  "deactivatedBy": {
+    "source": "virtual_switch",
+    "userId": "usr_abc123",
+    "userName": "DJ Moonbeam"
+  },
+  "deactivatedAt": "2026-03-07T23:45:00Z"
+}
+```
+
+**Error responses**:
+- `409 Conflict`: Auto-DJ is not currently active.
+- `403 Forbidden`: Insufficient permissions.
+
+**Side effects**:
+- Orchestrator calls `POST /flowsheet/end` on Backend-Service (and/or `finishRadioShow` on tubafrenzy) to end the show.
+- Orchestrator stops subscribing to AzuraCast.
+- If the Arduino is connected, the orchestrator sends it a `pause` command.
+
+#### `GET /api/auto-dj/status`
+
+Returns the current auto-DJ status. Available to any authenticated user (read-only).
+
+**Auth**: Better Auth session/JWT. Requires `dj` role or higher for full status; unauthenticated users receive a minimal response (active/inactive only).
+
+**Response** (200):
+```json
+{
+  "active": true,
+  "activatedBy": {
+    "source": "virtual_switch",
+    "userId": "usr_abc123",
+    "userName": "DJ Moonbeam"
+  },
+  "activatedAt": "2026-03-07T22:15:00Z",
+  "showId": 789,
+  "currentTrack": {
+    "artist": "Juana Molina",
+    "title": "la paradoja",
+    "album": "DOGA",
+    "detectedAt": "2026-03-07T23:42:18Z"
+  },
+  "device": {
+    "online": true,
+    "transport": "ethernet",
+    "lastHeartbeat": "2026-03-07T23:44:30Z",
+    "relayState": "auto_dj_active"
+  }
+}
+```
+
+When auto-DJ is inactive:
+```json
+{
+  "active": false,
+  "lastDeactivatedAt": "2026-03-07T20:00:00Z",
+  "lastDeactivatedBy": {
+    "source": "relay",
+    "detail": "Live DJ detected"
+  },
+  "device": {
+    "online": true,
+    "transport": "ethernet",
+    "lastHeartbeat": "2026-03-07T23:44:30Z",
+    "relayState": "dj_live"
+  }
+}
+```
+
+The `device` block is null if the Arduino has never connected.
+
+### Activation Sources
+
+The orchestrator tracks three activation sources:
+
+| Source | Trigger | How it reaches the orchestrator |
+|--------|---------|-------------------------------|
+| `virtual_switch` | DJ clicks activate/deactivate in dj-site | `POST /api/auto-dj/activate` or `/deactivate` |
+| `button` | Physical mushroom button press on Arduino | Arduino sends a `toggle` message over the management channel (WebSocket or HTTP) |
+| `relay` | Mixing board AUX relay state change | Arduino reports relay state in heartbeat; orchestrator auto-deactivates when relay indicates a live DJ is broadcasting |
+
+### Conflict Resolution
+
+When multiple sources interact:
+
+1. **Live DJ always wins.** If the relay reports a live DJ (`is_live: true` from AzuraCast, or relay open), the orchestrator deactivates auto-DJ regardless of the virtual switch state. The status response shows `deactivatedBy.source: "relay"`.
+
+2. **Button and virtual switch are equivalent.** Both toggle the orchestrator's activation state. The last action wins. There is no precedence between them.
+
+3. **Reactivation after live DJ.** When the relay transitions back to auto-DJ-active (live DJ signs off), the orchestrator does NOT automatically reactivate. A DJ must explicitly activate via the virtual switch or the physical button. This prevents the auto-DJ from unexpectedly resuming after a DJ finishes their show.
+
+### Button Toggle via Management Channel
+
+The Arduino sends a new message type over the management channel when the physical button is pressed:
+
+```json
+{
+  "type": "button_toggle",
+  "timestamp": 1709852100
+}
+```
+
+The orchestrator responds by activating or deactivating (toggling the current state). The ack uses the standard `AutoDJAck` schema with an optional `result` field:
+
+```json
+{
+  "type": "ack",
+  "id": "btn_1709852100",
+  "status": "ok",
+  "result": { "active": true }
+}
+```
+
+The `result` field is an optional extension to the existing `AutoDJAck` schema (which has `type`, `id`, `status`, and optional `error`). Adding an optional `result: object` field is backward-compatible -- existing ack consumers ignore unknown fields. The Arduino uses `result.active` to update its local knowledge of the orchestrator's state (for the status LED), but does not depend on it for state machine transitions.
+
+Over WiFi fallback, the button press is reported in the next heartbeat:
+
+```json
+{
+  "type": "heartbeat",
+  "button_press_count": 1,
+  ...
+}
+```
+
+The `button_press_count` field is the number of button presses since the last heartbeat. The Arduino increments a counter on each debounced press and resets it to 0 after the heartbeat is sent. The orchestrator toggles state only if the count is odd (even presses cancel out). This eliminates the edge case where multiple presses between heartbeats produce the wrong result -- a boolean flag could not distinguish 1 press from 2.
+
+## 2. dj-site UI Component
+
+### Location
+
+The auto-DJ status indicator lives in the **dashboard layout header**, visible on all authenticated pages. It should not be in the Appbar (which is a small fixed-position element for version/theme), but rather in the main content header area where DJs already see context about the current show.
+
+### Component: `AutoDJStatusBanner`
+
+A banner component that appears at the top of the dashboard when auto-DJ is active, and shows a compact indicator when inactive.
+
+**Active state:**
+- Background: amber/warning tone (MUI Joy `warning` color)
+- Content: "Auto DJ is active" with current track info (artist - title) and a "Deactivate" button
+- The "Deactivate" button is visible to DJs with `dj` role or higher
+
+**Inactive state:**
+- Compact: a small "Auto DJ: Off" indicator, or hidden entirely if the DJ is in the middle of their own show (no point showing auto-DJ status while they're live)
+- An "Activate" button is available for DJs when no live show is in progress
+
+**Device offline:**
+- If `device.online` is false, show a subtle warning icon with tooltip: "Auto DJ hardware is offline"
+
+### RTK Query Integration
+
+New API slice at `lib/features/autoDJ/api.ts`:
+
+```typescript
+// The orchestrator is a separate service from Backend-Service.
+// A new base query function is needed with its own env var.
+const orchestratorBaseQuery = fetchBaseQuery({
+  baseUrl: `${process.env.NEXT_PUBLIC_ORCHESTRATOR_URL}/api/auto-dj`,
+  prepareHeaders: async (headers) => {
+    const token = await getJWTToken();
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    return headers;
+  },
+});
+
+export const autoDJApi = createApi({
+  reducerPath: "autoDJApi",
+  baseQuery: orchestratorBaseQuery,
+  tagTypes: ["AutoDJStatus"],
+  endpoints: (builder) => ({
+    getStatus: builder.query<AutoDJStatus, void>({
+      query: () => "/status",
+      providesTags: ["AutoDJStatus"],
+      // Poll every 10 seconds for near-real-time status
+      pollingInterval: 10_000,
+    }),
+    activate: builder.mutation<AutoDJActivateResponse, void>({
+      query: () => ({ url: "/activate", method: "POST" }),
+      invalidatesTags: ["AutoDJStatus"],
+    }),
+    deactivate: builder.mutation<AutoDJDeactivateResponse, void>({
+      query: () => ({ url: "/deactivate", method: "POST" }),
+      invalidatesTags: ["AutoDJStatus"],
+    }),
+  }),
+});
+```
+
+**Note on service routing**: The orchestrator is deployed as a standalone service on Railway, separate from Backend-Service. dj-site needs a `NEXT_PUBLIC_ORCHESTRATOR_URL` environment variable pointing to the orchestrator's URL. The `orchestratorBaseQuery` reuses the same JWT auth as `backendBaseQuery` (Better Auth tokens are valid across services that share the same JWKS endpoint), but routes to a different host.
+
+### Types
+
+New type file at `lib/features/autoDJ/types.ts`, mirroring the API response shapes defined in section 1. These types should ultimately come from `@wxyc/shared/auto-dj` (generated from `api.yaml`), but can be defined locally in dj-site until the shared package is updated.
+
+### Polling vs. WebSocket
+
+The initial implementation uses RTK Query polling (10-second interval). This is simple and sufficient -- auto-DJ status changes are infrequent (minutes to hours between transitions). A future optimization could use Server-Sent Events from the Backend-Service `/events` endpoint to push status changes, but polling is the right starting point.
+
+## 3. Arduino Button Input
+
+### Hardware
+
+- **Button**: Industrial 22mm mushroom head, momentary (spring return), 1NO+1NC contacts, in a control station enclosure box
+- **Pin**: D5 (`BUTTON_PIN`), configured as `INPUT_PULLUP`
+- **Wiring**: Button NO contact to D5, common terminal to GND
+- **Debounce**: 50ms (same as relay), handled by a new `ButtonMonitor` class following the `RelayMonitor` pattern
+
+D5 is chosen because D2 (relay) and D3 (status LED) are taken, D4 is the Ethernet Shield Rev2's SD card chip select (even if unused, the shield's PCB connects D4 to the SD card slot -- using it for the button would create a latent conflict), and D10-D13 are reserved for the Ethernet Shield SPI bus (Phase 2). D5-D9 are all free.
+
+### State Machine Changes
+
+The button does NOT directly control the state machine. Instead:
+
+1. `ButtonMonitor` detects a debounced press (rising edge on release, or falling edge on press -- TBD based on the specific button's NO wiring)
+2. The main loop sends a `button_toggle` message to the orchestrator via the management channel
+3. The orchestrator decides whether to activate or deactivate
+4. The orchestrator's response flows back as a command, which the state machine already handles
+
+This keeps the state machine pure and the Arduino "dumb" -- all activation logic lives in the orchestrator.
+
+### Fallback: No Orchestrator
+
+Before the orchestrator is implemented, the button has no effect. The Arduino continues to operate in relay-only mode. The button input is wired and debounced, but the `button_toggle` message has nowhere to go. This is fine -- the button hardware can be installed ahead of the orchestrator software.
+
+## 4. Document Updates
+
+### `docs/wiring.md`
+
+Add button pin assignment:
+
+| Pin | Function | Mode | Wiring |
+|-----|----------|------|--------|
+| D5 | Manual toggle button | `INPUT_PULLUP` | Button NO terminal -> D5, common terminal -> GND |
+
+Update the wiring diagram to include the button.
+
+### `docs/networking-spec.md`
+
+Add new sections (do NOT renumber existing sections -- that would break cross-references throughout the document):
+
+- **New section 2.7 "Activation Sources"**: Covers relay, button, and virtual switch as activation sources, with the conflict resolution rules from this plan
+- **New section 3.10 "Virtual Switch API"**: The orchestrator-facing endpoints defined in this plan (activate, deactivate, status). Note: these are not Arduino-facing protocols (unlike the rest of section 3), but they are included here because the networking spec is the single source of truth for all auto-DJ network traffic and the orchestrator README explicitly references it
+- **Section 3.6.2**: Add `button_toggle` to the WebSocket message types table
+- **Section 3.7**: Add `button_press_count` field to the HTTP heartbeat schema
+- **Section 5.2**: Add `AutoDJButtonToggle`, `AutoDJActivateResponse`, `AutoDJDeactivateResponse`, `AutoDJStatus` schemas to the `api.yaml` additions. Add `AutoDJButtonToggle` to the `AutoDJWebSocketMessage` `oneOf` discriminated union. Extend `AutoDJAck` with optional `result: object` field
+- **Section 8**: Add open question about button debounce edge (press vs. release)
+
+Also reconcile a pre-existing discrepancy: the `AutoDJHeartbeat` schema in section 5.2.2 lists state values `BOOTING, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW`, but the actual `State` enum in `state_machine.h` includes `CONNECTING_WIFI` and `ERROR_STATE` as well. Fix the schema to include all seven states.
+
+### `docs/remote-administration.md`
+
+Add to pin assignments table:
+
+| Parameter | Current value | Purpose |
+|-----------|--------------|---------|
+| `BUTTON_PIN` | `5` | Manual toggle button (INPUT_PULLUP) |
+
+### `CLAUDE.md` (this repo)
+
+Add button and virtual switch to the key files table and development notes.
+
+### Orchestrator `README.md`
+
+Update the architecture diagram to include the physical button path and the virtual switch API endpoints. Fix the section references table to point to the actual networking spec sections. The current README references sections that do not exist (2.2 "Virtual Switch Activation", 2.3 "Conflict Resolution", 3.4 "Auto-DJ activation API"). The corrected mapping:
+
+| Orchestrator README currently says | Should reference |
+|---|---|
+| 2.2 Virtual Switch Activation | 2.7 Activation Sources (new) |
+| 2.3 Conflict Resolution | 2.7 Activation Sources (new, subsection on conflict resolution) |
+| 2.6 Dual-Database Architecture | 2.3 Dual-Backend Architecture |
+| 3.4 Auto-DJ activation API | 3.10 Virtual Switch API (new) |
+| 3.5 Flowsheet write pipeline | 3.3-3.4 (tubafrenzy + Backend-Service flowsheet operations) |
+| 3.8-3.9 Arduino management channel | 3.6-3.8 (WebSocket management + HTTP fallback + server-side endpoints) |
+
+## 5. Sequencing
+
+This plan produces spec documents only. Implementation is tracked separately.
+
+| Deliverable | Depends on |
+|------------|-----------|
+| Virtual switch API spec (networking-spec.md additions) | This plan |
+| dj-site UI spec (component + RTK Query design) | This plan |
+| `api.yaml` schema additions for virtual switch types | Virtual switch API spec |
+| Arduino button wiring spec (wiring.md, config.h) | This plan |
+| Orchestrator README updates | Virtual switch API spec |
+
+The virtual switch API spec is the foundation. The dj-site UI and Arduino button specs can proceed in parallel once the API shape is defined.

--- a/docs/plan-button-and-virtual-switch.md
+++ b/docs/plan-button-and-virtual-switch.md
@@ -20,7 +20,7 @@ The networking spec (sections 2.4, 2.6, 3.8) defines management server endpoints
 - Spec the dj-site UI component for auto-DJ status
 - Add physical button to the Arduino wiring spec
 - Update the networking spec with the missing virtual switch sections
-- Update wiring.md, config.h docs, and CLAUDE.md
+- Update wiring.md, remote-administration.md, and CLAUDE.md
 
 ### Out of scope
 
@@ -102,7 +102,7 @@ Deactivates the auto-DJ system. The orchestrator ends the current show and stops
 
 Returns the current auto-DJ status. Available to any authenticated user (read-only).
 
-**Auth**: Better Auth session/JWT. Requires `dj` role or higher for full status; unauthenticated users receive a minimal response (active/inactive only).
+**Auth**: Better Auth session/JWT. Requires `dj` role or higher.
 
 **Response** (200):
 ```json
@@ -157,7 +157,7 @@ The orchestrator tracks three activation sources:
 | Source | Trigger | How it reaches the orchestrator |
 |--------|---------|-------------------------------|
 | `virtual_switch` | DJ clicks activate/deactivate in dj-site | `POST /api/auto-dj/activate` or `/deactivate` |
-| `button` | Physical mushroom button press on Arduino | Arduino sends a `toggle` message over the management channel (WebSocket or HTTP) |
+| `button` | Physical mushroom button press on Arduino | Arduino sends a `button_toggle` message over the management channel (WebSocket or HTTP) |
 | `relay` | Mixing board AUX relay state change | Arduino reports relay state in heartbeat; orchestrator auto-deactivates when relay indicates a live DJ is broadcasting |
 
 ### Conflict Resolution
@@ -255,7 +255,7 @@ export const autoDJApi = createApi({
       // Poll every 10 seconds for near-real-time status
       pollingInterval: 10_000,
     }),
-    activate: builder.mutation<AutoDJActivateResponse, void>({
+    activate: builder.mutation<AutoDJStatus, void>({
       query: () => ({ url: "/activate", method: "POST" }),
       invalidatesTags: ["AutoDJStatus"],
     }),
@@ -295,7 +295,7 @@ The button does NOT directly control the state machine. Instead:
 1. `ButtonMonitor` detects a debounced press (rising edge on release, or falling edge on press -- TBD based on the specific button's NO wiring)
 2. The main loop sends a `button_toggle` message to the orchestrator via the management channel
 3. The orchestrator decides whether to activate or deactivate
-4. The orchestrator's response flows back as a command, which the state machine already handles
+4. The orchestrator's response flows back as an ack with `result.active`, which the management client uses to update local state (e.g., status LED)
 
 This keeps the state machine pure and the Arduino "dumb" -- all activation logic lives in the orchestrator.
 
@@ -323,7 +323,7 @@ Add new sections (do NOT renumber existing sections -- that would break cross-re
 - **New section 3.10 "Virtual Switch API"**: The orchestrator-facing endpoints defined in this plan (activate, deactivate, status). Note: these are not Arduino-facing protocols (unlike the rest of section 3), but they are included here because the networking spec is the single source of truth for all auto-DJ network traffic and the orchestrator README explicitly references it
 - **Section 3.6.2**: Add `button_toggle` to the WebSocket message types table
 - **Section 3.7**: Add `button_press_count` field to the HTTP heartbeat schema
-- **Section 5.2**: Add `AutoDJButtonToggle`, `AutoDJActivateResponse`, `AutoDJDeactivateResponse`, `AutoDJStatus` schemas to the `api.yaml` additions. Add `AutoDJButtonToggle` to the `AutoDJWebSocketMessage` `oneOf` discriminated union. Extend `AutoDJAck` with optional `result: object` field
+- **Section 5.2**: Add `AutoDJButtonToggle`, `AutoDJStatus`, `AutoDJDeactivateResponse`, `AutoDJActivationSource`, `AutoDJCurrentTrack`, `AutoDJDeviceSummary` schemas to the `api.yaml` additions. Add `AutoDJButtonToggle` to the `AutoDJWebSocketMessage` `oneOf` discriminated union. Extend `AutoDJAck` with optional `result: object` field
 - **Section 8**: Add open question about button debounce edge (press vs. release)
 
 Also reconcile a pre-existing discrepancy: the `AutoDJHeartbeat` schema in section 5.2.2 lists state values `BOOTING, IDLE, STARTING_SHOW, AUTO_DJ_ACTIVE, ENDING_SHOW`, but the actual `State` enum in `state_machine.h` includes `CONNECTING_WIFI` and `ERROR_STATE` as well. Fix the schema to include all seven states.

--- a/docs/remote-administration.md
+++ b/docs/remote-administration.md
@@ -112,7 +112,8 @@ These are physical wiring decisions that can only change if the hardware is rewi
 |-----------|--------------|---------|
 | `RELAY_PIN` | `2` | Mixing board AUX relay contact (INPUT_PULLUP) |
 | `STATUS_LED_PIN` | `3` | External status LED |
-| `DEBOUNCE_MS` | `50` | Relay debounce window |
+| `BUTTON_PIN` | `5` | Manual toggle button (INPUT_PULLUP) |
+| `DEBOUNCE_MS` | `50` | Relay and button debounce window |
 
 ### Operational Controls
 

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -4,6 +4,7 @@
 
 - **Board:** Arduino Giga R1 WiFi
 - **Relay:** Dry contact from mixing board AUX channel
+- **Button:** Industrial 22mm mushroom head, momentary (spring return), 1NO+1NC, in control station enclosure
 - **LED:** Standard LED + 220 ohm resistor (optional status indicator)
 
 ## Pin Assignments
@@ -11,8 +12,9 @@
 | Pin | Function | Mode | Wiring |
 |-----|----------|------|--------|
 | D2 | Relay contact input | `INPUT_PULLUP` | Relay terminal -> D2, other terminal -> GND |
-| GND | Common ground | -- | Shared with relay contact |
 | D3 | Status LED | `OUTPUT` | D3 -> 220 ohm -> LED anode, cathode -> GND |
+| D5 | Manual toggle button | `INPUT_PULLUP` | Button NO terminal -> D5, common terminal -> GND |
+| GND | Common ground | -- | Shared with relay, button, and LED |
 | LED_BUILTIN | Heartbeat | `OUTPUT` | Onboard LED (blinks every second) |
 
 ## Wiring Diagram
@@ -21,6 +23,10 @@
 Mixing Board AUX Relay (dry contact)
     Terminal A ──────── D2 (INPUT_PULLUP)
     Terminal B ──────── GND
+
+Manual Toggle Button (22mm mushroom head, momentary)
+    NO terminal ──────── D5 (INPUT_PULLUP)
+    Common terminal ──── GND
 
 Status LED
     D3 ─── 220 ohm ─── LED (+) ─── LED (-) ─── GND
@@ -39,8 +45,16 @@ The status LED mirrors this state:
 
 The built-in LED blinks once per second as a heartbeat indicator.
 
+## Manual Toggle Button
+
+A 22mm industrial mushroom head button (momentary, spring return) in a control station enclosure box provides a physical toggle for the auto-DJ system. Pressing the button sends a toggle command to the orchestrator via the management channel. The orchestrator decides whether to activate or deactivate based on its current state.
+
+The button uses the NO (normally open) contact. At rest, D5 reads HIGH (internal pullup). When pressed, the contact closes and D5 reads LOW (pulled to GND). The `ButtonMonitor` class detects this transition using the same 50ms debounce pattern as the relay.
+
+The button does NOT directly control the Arduino's state machine. All activation logic lives in the orchestrator. Before the orchestrator is deployed, the button is wired and debounced but has no effect -- the Arduino continues to operate in relay-only mode.
+
+**Pin choice:** D5 is used because D4 is the Ethernet Shield Rev2's SD card chip select (the shield's PCB connects D4 to the SD card slot even when unused). D10-D13 are reserved for the Ethernet Shield SPI bus.
+
 ## Debouncing
 
-Relay contacts bounce for up to 50ms during transitions. The software debounce
-in `relay_monitor.cpp` requires the pin state to remain stable for 50ms before
-registering a state change.
+Both the relay and the button use 50ms software debounce. The pin state must remain stable for 50ms before a state change is registered. The relay debounce is in `relay_monitor.cpp`; the button debounce follows the same pattern in `button_monitor.cpp`.


### PR DESCRIPTION
## Summary

- Spec the virtual switch API on the orchestrator (activate/deactivate/status endpoints)
- Add physical button wiring (D5, 22mm mushroom head, debounced)
- Design the dj-site `AutoDJStatusBanner` component with RTK Query polling
- Update networking-spec.md with new sections, schemas, and message types

Closes #19

## Changes

**networking-spec.md** (+357 lines):
- New section 2.7: Activation Sources (relay, button, virtual switch) with conflict resolution
- New section 3.10: Virtual Switch API (activate, deactivate, status endpoints)
- `button_toggle` WebSocket message type in 3.6.2
- `button_press_count` field in heartbeat schema
- 6 new OpenAPI schemas (AutoDJButtonToggle, AutoDJStatus, AutoDJActivationSource, AutoDJCurrentTrack, AutoDJDeviceSummary, AutoDJDeactivateResponse)
- Fixed state enum to include all 7 values (was missing CONNECTING_WIFI, ERROR_STATE)
- Updated TypeScript extensions and consumer matrix
- New open questions 17-18

**wiring.md**: D5 button pin, wiring diagram, button behavior docs
**remote-administration.md**: BUTTON_PIN parameter
**CLAUDE.md**: button_monitor key file reference
**plan-button-and-virtual-switch.md**: Full plan document

## Test plan

- [ ] Verify no section number conflicts in networking-spec.md
- [ ] Verify all cross-references resolve (section links, schema refs)
- [ ] Verify D5 has no pin conflicts with existing hardware or planned Ethernet Shield
- [ ] Verify OpenAPI schema YAML is syntactically valid